### PR TITLE
Add links to boost dependency report

### DIFF
--- a/user-guide/modules/ROOT/pages/common-introduction.adoc
+++ b/user-guide/modules/ROOT/pages/common-introduction.adoc
@@ -27,4 +27,4 @@ Each of these areas is a significant field in its own right, with specific techn
 
 == See Also
 
-* https://pdimov.github.io/boostdep-report/[boost Dependency Report]
+* https://pdimov.github.io/boostdep-report/[Boost Dependency Report]

--- a/user-guide/modules/ROOT/pages/common-introduction.adoc
+++ b/user-guide/modules/ROOT/pages/common-introduction.adoc
@@ -24,3 +24,7 @@ xref:task-text-processing.adoc[] involves the manipulation and analysis of text 
 xref:testing-debugging.adoc[] is a crucial part of the development process, aimed at evaluating the functionality of software applications to ensure they meet the specified requirements and to identify any bugs or issues. This might include writing unit tests for individual components, integration tests that evaluate how these components work together, and end-to-end tests that assess the system as a whole. 
 
 Each of these areas is a significant field in its own right, with specific techniques, practices, and tools that can be used to effectively tackle the challenges they present.
+
+== See Also
+
+* https://pdimov.github.io/boostdep-report/[boost Dependency Report]

--- a/user-guide/modules/ROOT/pages/explore-the-content.adoc
+++ b/user-guide/modules/ROOT/pages/explore-the-content.adoc
@@ -98,5 +98,6 @@ For example:
 
 == See Also
 
+* https://pdimov.github.io/boostdep-report/[boost Dependency Report]
 * xref:faq.adoc[]
 * xref:resources.adoc[]

--- a/user-guide/modules/ROOT/pages/explore-the-content.adoc
+++ b/user-guide/modules/ROOT/pages/explore-the-content.adoc
@@ -98,6 +98,6 @@ For example:
 
 == See Also
 
-* https://pdimov.github.io/boostdep-report/[boost Dependency Report]
+* https://pdimov.github.io/boostdep-report/[Boost Dependency Report]
 * xref:faq.adoc[]
 * xref:resources.adoc[]

--- a/user-guide/modules/ROOT/pages/getting-started.adoc
+++ b/user-guide/modules/ROOT/pages/getting-started.adoc
@@ -900,6 +900,7 @@ Great job!
 
 You might like to scan the examples folders of some of the other libraries that you are interested in, and create and run projects to get them running.
 
-Once you are more experienced with Boost, you might like to build and install only those libraries you require.
+Once you are more experienced with Boost, you might like to build and install only those libraries you require. To this end, it can be helpful to know the _dependencies_ that your target libraries have. This includes both _primary dependencies_ (the libraries directly referenced by your target library) and _secondary dependencies_ (the libraries not referenced by your target library, but referenced by the primary or other secondary libraries). To aid you in determining this information, refer to the https://pdimov.github.io/boostdep-report/[boost Dependency Report]. This report is updated with each public release of Boost.
+
 
 

--- a/user-guide/modules/ROOT/pages/getting-started.adoc
+++ b/user-guide/modules/ROOT/pages/getting-started.adoc
@@ -900,7 +900,7 @@ Great job!
 
 You might like to scan the examples folders of some of the other libraries that you are interested in, and create and run projects to get them running.
 
-Once you are more experienced with Boost, you might like to build and install only those libraries you require. To this end, it can be helpful to know the _dependencies_ that your target libraries have. This includes both _primary dependencies_ (the libraries directly referenced by your target library) and _secondary dependencies_ (the libraries not referenced by your target library, but referenced by the primary or other secondary libraries). To aid you in determining this information, refer to the https://pdimov.github.io/boostdep-report/[boost Dependency Report]. This report is updated with each public release of Boost.
+Once you are more experienced with Boost, you might like to build and install only those libraries you require. To this end, it can be helpful to know the _dependencies_ that your target libraries have. This includes both _primary dependencies_ (the libraries directly referenced by your target library) and _secondary dependencies_ (the libraries not referenced by your target library, but referenced by the primary or other secondary libraries). To aid you in determining this information, refer to the https://pdimov.github.io/boostdep-report/[Boost Dependency Report]. This report is updated with each public release of Boost.
 
 
 

--- a/user-guide/modules/ROOT/pages/resources.adoc
+++ b/user-guide/modules/ROOT/pages/resources.adoc
@@ -45,6 +45,6 @@ For more specific technical questions, Stack Overflow has many questions and ans
 
 == See Also
 
-* https://pdimov.github.io/boostdep-report/[boost Dependency Report]
+* https://pdimov.github.io/boostdep-report/[Boost Dependency Report]
 * xref:explore-the-content.adoc[]
 * xref:faq.adoc[]

--- a/user-guide/modules/ROOT/pages/resources.adoc
+++ b/user-guide/modules/ROOT/pages/resources.adoc
@@ -45,6 +45,6 @@ For more specific technical questions, Stack Overflow has many questions and ans
 
 == See Also
 
+* https://pdimov.github.io/boostdep-report/[boost Dependency Report]
 * xref:explore-the-content.adoc[]
 * xref:faq.adoc[]
-


### PR DESCRIPTION
Add a short explanation of dependencies to the Getting Started section, and a link to the dependency report. And in a few appropriate places add a "See Also" link to this report.