### PR TITLE
Feedback on Contributor Guide

### DIFF
--- a/contributor-guide/modules/ROOT/pages/best-practices.adoc
+++ b/contributor-guide/modules/ROOT/pages/best-practices.adoc
@@ -21,7 +21,6 @@ Some libraries are published with the intended primary audience, or in some case
 | boost:config[] | Helps Boost library developers adapt to compiler idiosyncrasies. The range of macros can be extended, if required, with boost:predef[].
 | boost:core[] | A collection of simple core utilities with minimal dependencies. The range of utilities can be extended, if required, with boost:utility[]
 | boost:assert[] | Customizable assert macros.
-| boost:static-assert[] | Static compile time assertions.
 | boost:throwException[] | A common infrastructure for throwing exceptions from Boost libraries.
 | boost:mp11[] | Provides a template metaprogramming framework, useful if metaprogramming is a feature of your new library.
 |===

--- a/contributor-guide/modules/ROOT/pages/docs/documentation-components.adoc
+++ b/contributor-guide/modules/ROOT/pages/docs/documentation-components.adoc
@@ -79,9 +79,7 @@ Such extensions are generally one of the following:
 convention
 
 Interface convention requirements are stated as generally as possible.
-Instead of stating "`class X` has to define a member function
-`operator++()`," the interface requires "for any object `x` of
-`class X`, `++x` is defined." That is, whether the operator is a member is unspecified.
+For example, instead of stating " `class X` has to define a member function `pass:[operator++]()` ", say " the interface requires for any object `x` of `class X`, `pass:[++x]` is defined" (noting that whether the operator is a member or not is unspecified).
 
 Requirements are stated in terms of well-defined expressions, which
 define valid terms of the types that satisfy the requirements. For every set of requirements there is a table that specifies an initial set of

--- a/contributor-guide/modules/ROOT/pages/release-notes.adoc
+++ b/contributor-guide/modules/ROOT/pages/release-notes.adoc
@@ -93,7 +93,7 @@ The following examples show some different approaches. Note how many rely on lin
 
 When you have completed the library release notes, add the required information to the `[section New Libraries]` or `[section Updated Libraries]` of the https://github.com/boostorg/website/tree/master/feed/history[Boostorg History]. Copy the formatting of the examples below, which for reference is https://www.boost.org/doc/libs/1_83_0/doc/html/quickbook.html[Quickbook format].
 
-The examples below come from the https://github.com/boostorg/website/blob/master/feed/history/boost_1_83_0.qbk[boost_183_0.qbk] file:
+The examples below come from the https://github.com/boostorg/website/blob/master/feed/history/boost_1_83_0.qbk[boost_1_83_0.qbk] file:
 
 [source,bash]
 ----


### PR DESCRIPTION
Formatting feedback on Release Notes, Documentation Components, and remove StaticAssert from Best Practices.
fix #190
fix #187
fix #188