### PR TITLE
Replace links into old website

### DIFF
--- a/contributor-guide/modules/ROOT/pages/getting-involved.adoc
+++ b/contributor-guide/modules/ROOT/pages/getting-involved.adoc
@@ -23,7 +23,7 @@ The Boost mailing list is a platform for discussions and communications related 
 
 * *Support*: Newcomers or users encountering difficulties can seek help from the community. Experienced members provide solutions, advice, and share their experiences.
 
-If you do join, follow the https://www.boost.org/community/policy.html[guidelines and rules] of the mailing list, as it helps in maintaining a respectful and productive environment.
+If you do join, follow the xref:user-guide:ROOT:discussion-policy.adoc[] of the mailing list, as it helps in maintaining a respectful and productive environment.
 
 To subscribe to the Developers Mailing List go https://lists.boost.org/mailman/listinfo.cgi/boost[Boost developers' mailing list].
 
@@ -71,3 +71,7 @@ NOTE: All libraries in Boost are tested when the super-project is tested, so eve
 == Contribute a New Library
 
 This is the big dog of contributions. There are developers who have contributed several libraries to Boost. Start by reading the xref:requirements/library-requirements.adoc[] section, and make sure to engage the Boost community before getting too deep into a massive coding project.
+
+== See Also
+
+* xref:formal-reviews:ROOT:index.adoc[]

--- a/contributor-guide/modules/ROOT/pages/requirements/license-requirements.adoc
+++ b/contributor-guide/modules/ROOT/pages/requirements/license-requirements.adoc
@@ -9,7 +9,7 @@ Official repository: https://github.com/boostorg/website-v2-docs
 = License Requirements
 :navtitle: License Requirements
 
-The preferred way to meet the license requirements is to use the https://www.boost.org/LICENSE_1_0.txt[Boost Software License]. See license information. If for any reason you do not intend to use the Boost Software License, please discuss the issues on the Boost developers mailing list first.
+The preferred way to meet the license requirements is to use xref:user-guide:ROOT:bsl.adoc[]. See license information. If for any reason you do not intend to use the Boost Software License, please discuss the issues on the Boost developers mailing list first.
 
 The license requirements:
 
@@ -25,3 +25,7 @@ The license requirements:
 * Must not require that the source code be available for execution or other binary uses of the library.
 
 * May restrict the use of the name and description of the library to the standard version found on the Boost web site.
+
+== See Also
+
+* xref:contributors-faq.adoc#boostsoftwarelicense[Contributors FAQ: Boost Software License]

--- a/user-guide/modules/ROOT/pages/intro.adoc
+++ b/user-guide/modules/ROOT/pages/intro.adoc
@@ -26,7 +26,7 @@ There are many advantages to using Boost in your C++ projects, the main one bein
 [disc]
 * Boost libraries are peer reviewed, well designed, and extensively tested.
 * Boost does not compete with the Standard Template Library (STL) for C++. Rather it complements the STL libraries with exciting new functionality. Many libraries that are now part of the STL started as Boost libraries.
-* Boost is open-source, and available for you to use in any of your projects. It is free, including for commercial projects. Refer to the https://www.boost.org/users/license.html[Boost Software License].
+* Boost is open-source, and available for you to use in any of your projects. It is free, including for commercial projects. Refer to xref:bsl.adoc[].
 * Boost allows for cross-platform development, with single source code. Boost supports: Windows, Linux variants, Apple OS X, IOS, Android, and Xbox.
 * The Boost Libraries are designed to be as independent as possible so that users can pick and choose the libraries they need without being forced to include unnecessary code. Some libraries do have dependencies on a few others, and typically these other libraries are loaded automatically if just a subset of the full collection of libraries is being installed.
 * Particular strengths of the Boost libraries include smart pointers, unit tests, lambda functions, function binding, regex, a file system, to name a few.


### PR DESCRIPTION
Replaced a couple of old links to the BSL, now referring to the page in the new docs, and one link to the old mailing list discussion policy again with a link into the new site discussion policy page.