### PR TITLE
Formal Reviews Submission Process updated

### DIFF
--- a/formal-reviews/modules/ROOT/nav.adoc
+++ b/formal-reviews/modules/ROOT/nav.adoc
@@ -6,8 +6,8 @@ file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 Official repository: https://github.com/boostorg/website-v2-docs
 ////
-* xref:index.adoc[Introduction to Boost Formal Reviews]
+* xref:index.adoc[]
 * xref:submissions.adoc[]
-* xref:writing-reviews.adoc[]
 * xref:managing-reviews.adoc[]
+* xref:writing-reviews.adoc[]
 * xref:review-results.adoc[]

--- a/formal-reviews/modules/ROOT/pages/index.adoc
+++ b/formal-reviews/modules/ROOT/pages/index.adoc
@@ -7,103 +7,21 @@ file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 Official repository: https://github.com/boostorg/website-v2-docs
 ////
 = Introduction to Boost Formal Reviews
-:navtitle: Formal Reviews
+:navtitle: Introduction
 
-When you feel that your library is ready for entry into Boost, you need to find at least one member (but preferably several) of the Boost community who is willing to publicly endorse your library for entry into Boost. A simple method of achieving this is to post to the https://www.boost.org/community/groups.html[Boost developers mailing list] a short description of your library, links to its Github and documentation, and a request for endorsements.
+This Formal Review Guide provides information for the three main roles in library submission:
 
-It is expected that those who endorse a library for review will have performed at least a cursory check of the library's suitability for Boost in terms of documentation, fit with the rest of Boost and usefulness. A public endorsement of a library for review means that from an initial glance, they believe that the library has a reasonable chance to be accepted during a formal review. The expectation is that these endorsers will themselves review of the library during formal review period, though this is not binding.
+. The authors who wish to submit the library to the Boost collection: refer to the xref:submissions.adoc[].
+. The _Review Manager_ who's job it is to lead and coordinate the review process: refer to xref:managing-reviews.adoc[].
+. The developers who test the submission, or elements of it, and write up their findings: refer to xref:writing-reviews.adoc[].
 
-Once you have a list of people who have publicly endorsed your library for review, email the https://www.boost.org/community/reviews.html#Wizard[Review Wizards] to request that your library be added to the https://www.boost.org/community/review_schedule.html[Boost Formal Review Schedule] where the following information will be shown:
+This guide also includes a comprehensive history of submissions, most with links to the rationale and announcements made during the evaluation process: refer to the xref:review-results.adoc[].
 
-[disc]
-* Submission
-* Submitter
-* Links to Source (GitHub), Documentation (HTML website)
- and any Incubator entry
-* Review Manager
-* Review Dates
+== Feedback
 
-== Seek a Review Manager
-
-In order to schedule a formal review, the author must find a capable volunteer to manage the review. This should be someone with knowledge of the library domain, and experience with the review process. See <<The Role of Review Manager>> for the responsibilities of the Review Manager.
-
-Authors can find community members interested in managing reviews through discussion of the library on the developer
-list. If no one steps forward to volunteer to manage the review, it is appropriate to contact an experienced Boost
-member who showed interest in the library. Be considerate that managing a review is a serious commitment; for this reason, it's better to contact the member off-list.
-
-If you cannot find a Review Manager after 3 weeks using the means above, and your submission is targeting eventual
-standardization, there is a list of Boost regulars who are also WG21 committee members who have volunteered to act as review managers in such cases. Please try them in the order listed:
- 
- . Zach Laine
- . Micheal Caisse
- . Matt Calabrese
- . EdwardDiener
- . Louis Dionne
- . Vinnie Falco
- . Glen Fernandes
- . David Sankel
-
-
-Once a potential Review Manager has been identified, contact the https://www.boost.org/community/reviews.html#Wizard[Review Wizards] for approval. The wizards approve Review Managers based on their level of participation in the Boost  community.
-
-The Review Wizards will coordinate with both the author and Review Manager to schedule a date convenient for both.
-
-== Formal Review
-
-Before your formal review begins, double-, triple-, and quadruple-check your library. Verify that every code example
-works, that all unit tests pass on at least two compilers on at least two major operating systems, and run your documentation through a spelling and grammar checker.
-
-Please do not modify your library on its *master* branch during a review. Instead, modify a separate *develop* branch in response to feedback and reviews. For bigger ticket items of work, open issues on your issue tracker so interested people can track the fixing of specific issues raised.
-
-The Review Manager will consider all the reviews made by members of the community and arrive at a decision on
-whether your library is rejected, conditionally accepted or unconditionally accepted. They will post a report summarizing the decision publicly. If conditions are attached to acceptance, you will need to implement those conditions or else undergo an additional formal review.
-
-== Fast Track Reviews
-
-To qualify for a fast track review:
-
-[disc]
-* The component must be small.
-
-* The technique must be already in use in Boost libraries and the new component provides a common implementation.
-
-* A full Boost-conformant implementation is available in the sandbox.
-
-* The Review Wizard determines that the proposal qualifies for fast track review.
-
-=== Fast Track Procedure
-
-. The Boost Review Wizard posts a review announcement to the main Boost developer's list. The fast track review period will normally last for 5 days. No two fast-track reviews will run in parallel. Fast track reviews may run during full reviews, though generally, this is to be avoided.
-
-. After the review period ends, the submitter will post a review summary containing proposed changes to the reviewed implementation.
-
-. The Review Wizard will accept or reject the proposed library and proposed changes.
-
-. After applying the proposed changes, the component is checked into the repository like any other library.
-
-== Mini-Reviews
-
-It is possible that in the review process some issues might need to be fixed as a _requirement_ for acceptance. If a review does result in conditions on acceptance, the Review Manager may request a _Mini-Review_, at a later date, to determine if the conditions have been met. The Mini-Review is usually conducted by the same Review Manager.
-
-== Boost Website Posting
-
-Once an accepted library is ready for inclusion on the Boost web site, the submitter is typically given Boost repository write access, and expected to check-in and maintain the library there. Contact the moderators if you need write access or direct use of the repository isn't possible for you.
-
-== Library Maintainer's Rights and Responsibilities
-
-By submitting a library to Boost, you accept responsibility for maintaining your library, or finding a qualified volunteer to serve as maintainer. You must be willing to put your library and documentation under a Boost-compatible license.
-
-You will be expected to respond to reasonable bug reports and questions on time and to participate as needed in discussions of your library on the Boost mailing lists.
-
-You are free to change your library in any way you wish, and you are encouraged to actively make improvements. However, peer review is an important part of the Boost process and as such you are also encouraged to get feedback from the Boost community before making substantial changes to the interface of an accepted library.
-
-If at some point you no longer wish to serve as maintainer of your library, it is your responsibility to make this known to the Boost community, and to find another individual to take your place.
-
-Libraries which have been abandoned will be put in care of the Community Maintenance Team.
-
+Feedback on any aspect of this documentation is encouraged, and is available by creating a https://github.com/cppalliance/site-docs/issues[New Issue].
 
 == See Also
 
 * xref:contributor-guide:ROOT:index.adoc[]
 * xref:user-guide:ROOT:index.adoc[]
-

--- a/formal-reviews/modules/ROOT/pages/managing-reviews.adoc
+++ b/formal-reviews/modules/ROOT/pages/managing-reviews.adoc
@@ -6,20 +6,20 @@ file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 Official repository: https://github.com/boostorg/website-v2-docs
 ////
-= Managing a Review
-:navtitle: Managing a Review
+= Managing Reviews
+:navtitle: Managing Reviews
 
-Before a library can be scheduled for formal review, an active Boost member (not connected with the library submission) must volunteer to be the _Review Manager_ for the library. Members may contact a library author on- or off-list to express interest in managing the review. The library author has to accept a person as a Review Manager.
+Before a library can be scheduled for formal review, an active Boost member (not connected with the library submission) must volunteer to be the _Review Manager_ for the library. Members may contact a library author on- or off-list to express interest in managing the review. The library author has to accept a person as a review manager.
 
-Before submitting a library, it will help to understand the role of the Review Manager.
+Before submitting a library, it will help to understand the role of the review manager.
 
 == The Role of Review Manager
 
-The Review Manager works through the following process:
+The review manager works through the following process:
 
 . Checks the submission to make sure it really is complete enough to warrant formal review. For full requirements, refer to the xref:contributor-guide:ROOT:requirements/library-requirements.adoc[]. If necessary, work with the submitter to verify the code compiles and runs correctly on several compilers and platforms.
 
-. Finalizes the schedule with the Review Wizard and the submitter.
+. Finalizes the schedule with the <<Review Wizards>> and the submitter.
 
 . Posts a notice of the review schedule on both the https://lists.boost.org/mailman/listinfo.cgi/boost[Boost developers' mailing list] and the https://lists.boost.org/mailman/listinfo.cgi/boost-announce[Boost-announce mailing list].
 
@@ -35,11 +35,20 @@ The Review Manager works through the following process:
 
 . Follows review discussions regarding the library, moderating or answering questions as needed.
 
-. Asks the Review Wizard for permission to extend the review schedule if it appears that too few reviews will be submitted during the review period.
+. Asks the <<Review Wizards>> for permission to extend the review schedule if it appears that too few reviews will be submitted during the review period.
 
-. Decides if there is consensus to accept the library and if there are any conditions attached. Consensus is not the same as a vote. *The Review Manager has discretion to weigh opinions based on authority or thoughtfulness.*
+. Decides if there is consensus to accept the library and if there are any conditions attached. Consensus is not the same as a vote. *The review manager has discretion to weigh opinions based on authority or thoughtfulness.*
 
-. Posts a notice of the review results on the https://lists.boost.org/mailman/listinfo.cgi/boost-users[Boost users mailing list] as well as the https://lists.boost.org/mailman/listinfo.cgi/boost[Boost developers' mailing list] and https://lists.boost.org/mailman/listinfo.cgi/boost-announce[Boost-announce mailing list]. A rationale is also helpful, but its extent is up to the Review Manager. If there are suggestions, or conditions that must be met before final inclusion, they should be stated. Concerns about the timeliness or quality of the review report should be brought to the Review Wizards off-list.
+. Posts a notice of the review results on the https://lists.boost.org/mailman/listinfo.cgi/boost-users[Boost users mailing list] as well as the https://lists.boost.org/mailman/listinfo.cgi/boost[Boost developers' mailing list] and https://lists.boost.org/mailman/listinfo.cgi/boost-announce[Boost-announce mailing list]. A rationale is also helpful, but its extent is up to the review manager. If there are suggestions, or conditions that must be met before final inclusion, they should be stated. Concerns about the timeliness or quality of the review report should be brought to the <<Review Wizards>> off-list.
+
+== Becoming a Review Manager
+
+To manage a review, you should have experience with the review process and knowledge of the library's domain. To volunteer to become a review manager, contact the current <<Review Wizards>>.
+
+[[reviewwizards]]
+=== Review Wizards
+
+Currently the review wizards are Mateusz Łoskot (mateusz@loskot.net) and John Phillips (johnphillipsithaca@gmail.com). 
 
 == See Also
 

--- a/formal-reviews/modules/ROOT/pages/review-results.adoc
+++ b/formal-reviews/modules/ROOT/pages/review-results.adoc
@@ -9,10 +9,11 @@ Official repository: https://github.com/boostorg/website-v2-docs
 = Boost Formal Review Schedule
 :navtitle: Review Schedule
 
-Reviews are scheduled when the review wizards approve a review manager and agree with the manager and author on dates. See xref:submissions.adoc[] for more information.
+Reviews are scheduled when the xref:managing-reviews.adoc#reviewwizards[Review Wizards] approve a review manager and agree with the manager and author on dates. See xref:submissions.adoc[] for more information.
 
 In addition to upcoming reviews, the schedule includes recent reviews already completed; that helps track review manager assignments and libraries reviewed but not yet posted on the website. There is often a lag between acceptance and site posting as authors address issues raised in the formal review.
 
+[[currentschedule]]
 == Current Schedule
 
 [cols="1,1,1,2,2",stripes=even,options="header",frame=none]
@@ -25,6 +26,7 @@ In addition to upcoming reviews, the schedule includes recent reviews already co
 
 In order for a review to proceed, a Boost member must volunteer to manage the review. This should be someone with experience with the review process and knowledge of the library's domain. If you would like to volunteer to become a review manager, refer to xref:managing-reviews.adoc[].
 
+[[pastreviewresults]]
 == Past Review Results and Milestones
 
 [cols="1,1,1,2,2",stripes=even,options="header",frame=none]

--- a/formal-reviews/modules/ROOT/pages/submissions.adoc
+++ b/formal-reviews/modules/ROOT/pages/submissions.adoc
@@ -1,339 +1,149 @@
 ////
 Copyright (c) 2024 The C++ Alliance, Inc. (https://cppalliance.org)
-
 Distributed under the Boost Software License, Version 1.0. (See accompanying
 file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
-
 Official repository: https://github.com/boostorg/website-v2-docs
 ////
 = Boost Library Submission Process
-:idprefix:
-:idseparator: -
+:navtitle: Submission Process
 
-*Legacy content, currently being updated.*
+This page describes the process a library developer goes through to get a library accepted into Boost.
 
-This page describes the process a library developer goes
- through to get a library accepted by Boost.
+== Steps for Getting a Library Accepted by Boost
 
+=== Learn about Boost
 
-See the [Boost Library
- Requirements and Guidelines](requirements.html) page for issues of content.
+Follow posts on the https://lists.boost.org/mailman/listinfo.cgi/boost[Boost developers' mailing list] for a while, or look through the https://lists.boost.org/Archives/boost/[message archives]. Explore this website. Learn the xref:contributor-guide:ROOT:requirements/library-requirements.adoc[]. Read the rest of this page to learn about the process. Search the web to get an idea of the commitment required to get a library into Boost. 
 
+There is a culture associated with Boost, aimed at encouraging high quality libraries by a process of discussion and refinement. Some libraries get past community review in less than two years from first concept, but most take longer, sometimes a lot longer. Five to ten years to get a library past review and into Boost is not unheard of, and you should prepare yourself for the personal investment required.
 
-## Steps for getting a library accepted by Boost:
+=== Determine Interest
 
+While participation in reviews for other submissions is not a prerequisite for submitting a library to Boost, it is highly recommended; it will acquaint you with the process and the emotional demands of a formal review. There's nothing that quite deflates the ego like having brilliant members of the pass:[C++] community critiquing your work, but, alas, it's worth it!
 
-* [1. Learn about Boost](#Learn)
-* [2. Determine interest](#interest)
-* [3. Start Development](#Development)
-* [4. Refinement](#Refinement)
-* [5. Getting seconded for review](#Seconded)
-* [6. Seek a Review Manager](#Seeking)
-* [7. Formal Review](#Review)
-* [8. Web site posting](#SitePosting)
-* [9. People page](#People)
-* [10. Lifecycle](#Lifecycle)
+Potential library submitters should be careful to research the prior art before beginning to design a new library. Unfortunately, now and then folks arrive at Boost with a new library into which they have invested many hours, only to find that Boost already has that functionality, and sometimes has had it for years. Candidates should also research libraries being developed by others intended for Boost - if you have an itch to scratch, often so have had others and collaboration developing their library is usually considerably more efficient than going at it alone.
 
+Potential library submitters should also be careful to publicize, canvas for, and gauge interest in their library, ideally before beginning it, but certainly before submitting it for review. Even a superbly designed library can fail review if there isn't enough interest in the subject matter; We can only review libraries with enough appeal to form a viable peer review. Ensuring that enough people are interested in your potential library goes a long way to ensure that.
 
-Learn about Boost
------------------
+There are many places to publicize and canvas for a library. The https://lists.boost.org/mailman/listinfo.cgi/boost[Boost developers' mailing list] ought to be your first stop in gauging interest in a possible new pass:[C++] library. Be prepared to pivot your design and focus until your proposed library finds traction. Other places useful for gauging interest in a library might be https://www.reddit.com/r/cpp/[Reddit/r/cpp].
 
+A message to the Boost developers mailing list might be as simple as "Is there any interest in a library which solves Traveling Salesperson problems in linear time?"
 
-Follow posts on the [main
- developers mailing list](/community/groups.html#main) for a while, or look through the
- [archives](/community/groups.html#archive). Explore
- the [web site](/). Learn the [Requirements](requirements.html). Read the rest of this
- page to learn about the process. Search the web to get an idea
- of the commitment required to get a library into Boost.
- 
+A bit of further description or snippet of code may be helpful. By the way, the preferred format for messages on the mailing list is plain text; not rich text, HTML, etc.
 
+Avoid posting lengthy descriptions, documentation, or code to the mailing list, and, please, no attachments. The best place to provide lengthy material is via. a web link. Project hosting services such as sourceforge, github, google code, and bitbucket serve well for this purpose.
 
-There is a culture associated with Boost, aimed at
- encouraging high quality libraries by a process of discussion
- and refinement. Some libraries get past community review
- in less than two years from first concept, but most take longer,
- sometimes a lot longer. Five to ten years to get a library past
- review and into Boost is not unheard of, and you should prepare
- yourself for the personal investment required.
+=== Start Development
 
+If response to an initial query indicates interest, then by all means make your library publicly available if you haven't already done so.
 
-Determine interest
-------------------
+Please commit your code to a version control system such as Git, and make your documentation available in HTML format on a public website such as Github. An issue tracker such as the one provided by Github is also highly recommended.
 
+Your library should contain material as if it were on the boost.org web site. The closer your library reflects the final directory structure and format of the web site, the better. This makes it possible for reviewers to simply copy your code into the Boost distribution for testing.
 
-While participation in reviews for other submissions is not a
- prerequisite for submitting a library to Boost, it is highly
- recommended; it will acquaint you with the process and the
- emotional demands of a formal review. There's nothing that quite
- deflates the ego like having brilliant members of the C++
- community critiquing your work, but, alas, it's worth it!
+Please verify that your library compiles and runs under at least two compilers. This flushes out obvious portability problems.
 
+It is recommended that you release your code under xref:user-guide:ROOT:bsl.adoc[the Boost Software License].
 
-Potential library submitters should be careful to
- research the prior art before beginning to design a
- new library. Unfortunately, now and then folks arrive at Boost
- with a new library into which they have invested many hours, only
- to find that Boost already has that functionality, and sometimes
- has had it for years. Candidates should also research libraries being
- developed by others intended for Boost - if you have an itch
- to scratch, often so have had others and collaboration
- developing their library is usually considerably more efficient
- than going at it alone.
-
-
-Potential library submitters should also be careful to
- publicise, canvas for, and gauge interest in their library,
- ideally before beginning it, but certainly before submitting it
- for review. Even a superbly designed library can fail review if
- there isn't enough interest in the subject matter; We can only
- review libraries with enough appeal to form a viable peer
- review. Ensuring that enough people are interested in your
- potential library goes a long way to ensure that.
-
-
-There are many places to publicise and canvas for a library.
- The Boost developers [mailing
- list](/community/groups.html) ought to be your first stop in gauging interest
- in a possible new C++ library. Be prepared to pivot your design
- and focus until your proposed library finds traction. Other
- places useful for gauging interest in a library might be [Reddit/r/cpp](https://www.reddit.com/r/cpp/).
-
-
-A message to the Boost developers mailing list
- might be as simple as "Is there any interest in a
- library which solves Travelling Salesperson problems in linear
- time?"
-
-
-A bit of further description or snippet of code may be
- helpful. By the way, the preferred format for messages on the
- mailing list is plain text; not rich text, HTML, etc.
-
-
-Avoid posting lengthy descriptions, documentation,
- or code to the mailing list, and, please, no attachments.
- The best place to provide lengthy material is via. a web link.
- Project hosting services such as sourceforge, github, google
- code, and bitbucket serve well for this purpose.
-
-
-Start Development
------------------
-
-
-If response to an initial query indicates interest, then
- by all means make your library publicly available if you haven't
- already done so.
-
-
-Please commit your code to a version control system such as
- Git, and make your documentation available in HTML format on
- a public website such as Github. An issue tracker such as the one
- provided by Github is also highly recommended.
-
-
-Your library should contain material as if it were on the
- boost.org web site. The closer your library reflects the
- final directory structure and format of the web site, the
- better. This makes it possible for reviewers to simply copy
- your code into the Boost distribution for testing.
-
-
-Please verify that your library compiles and runs under
- at least two compilers. This flushes out obvious portability
- problems.
-
-
-It is recommended that you release your code under the Boost
- Software License; see the [Requirements](requirements.html) page for more
- information.
-
-
-Refinement
-----------
-
+=== Refinement
 
 Discuss, refine, rewrite. Repeat until satisfied.
 
+The exact details of this process varies a lot. Usually it is public, on the mailing list, but frequently discussion happens in private emails. For some libraries the process is over quickly, but for others it goes on for months. It's often challenging, and sometimes veers into completely unexpected directions.
 
-The exact details of this process varies a lot. Usually it
- is public, on the mailing list, but frequently discussion
- happens in private emails. For some libraries the process is
- over quickly, but for others it goes on for months. It's
- often challenging, and sometimes veers into completely
- unexpected directions.
+The https://lists.boost.org/Archives/boost/[mailing list archives] of past messages is one way to see how this process worked for other Boost libraries.
 
+Alternatively, follow the status links in the previously submitted libraries listed in xref:review-results.adoc#pastreviewresults[Past Review Results and Milestones].
 
-The [archive](/community/groups.html#archive) of
- past messages is one way to see how this process worked for
- other Boost libraries.
+=== Getting Seconded for Review
 
+When you feel that your library is ready for entry into Boost, you need to find at least one member (but preferably several) of the Boost community who is willing to publicly endorse your library for entry into Boost. A simple method of achieving this is to post to the https://lists.boost.org/mailman/listinfo.cgi/boost[Boost developers' mailing list] a short description of your library, links to its github and documentation, and a request for endorsements.
 
-To get an idea of best practices with some samples of script
- and code in existing Boost libraries, see the
- [Best Practices Handbook](https://svn.boost.org/trac/boost/wiki/BestPracticeHandbook) on the Boost wiki.
+It is expected that those who endorse a library for review will have performed at least a cursory check of the library's suitability for Boost in terms of documentation, fit with the rest of Boost and usefulness. A public endorsement of a library for review means that from an initial glance, they believe that the library has a reasonable chance to be accepted during a formal review. The expectation is that these endorsers will themselves review of the library during formal review period, though this is not binding.
 
+Once you have a list of people who have publicly endorsed your library for review, email the https://lists.boost.org/mailman/listinfo.cgi/boost[Boost developers' mailing list] to request that your library be added to the xref:review-results.adoc#currentscheule[Current Schedule] where the following information will be shown:
 
-Getting seconded for review
----------------------------
-
-
-When you feel that your library is ready for entry into Boost,
- you need to find at least one member (but preferably several) of
- the Boost community who is willing to publicly endorse your
- library for entry into Boost. A simple method of achieving this
- is to post to [the Boost
- developers mailing list](/community/groups.html) a short description of your
- library, links to its github and documentation, and a request for
- endorsements.
-
-
-It is expected that those who endorse a library for review
- will have performed at least a cursory check of the library's
- suitability for Boost in terms of documentation, fit with
- the rest of Boost and usefulness. A public endorsement of a
- library for review means that from an initial glance, they
- believe that the library has a reasonable chance to be accepted
- during a formal review. The expectation is that these endorsers
- will themselves review of the library during formal review
- period, though this is not binding.
-
-
-Once you have a list of people who have publicly endorsed
- your library for review, email [the Review Wizards](/community/reviews.html#Wizard)
- to request that your library be added to [the review queue](/community/review_schedule.html)
- where the following information will be shown:
-
-
-* Submission
-* Submitter
-* Links to Source (GitHub), Documentation (HTML website)
- and any Incubator entry
-* Names of members who endorse this submission for review
+* Submission (Library name)
+* Submitter (author or authors)
 * Review Manager
-* Review Dates
+* Review Dates (start and end dates of the review period)
+* Links to the status of the review, given as announcements.
 
+=== Seek a Review Manager
 
-Seek a Review Manager
----------------------
+In order to schedule a formal review, the author must find a capable volunteer to manage the review. This should be someone with knowledge of the library domain, and experience with the review process. See xref:managing-reviews.adoc[] for the responsibilities of the review manager.
 
+Authors can find community members interested in managing reviews through discussion of the library on the developer list. If no one steps forward to volunteer to manage the review, it is appropriate to contact an experienced Boost member who showed interest in the library. Be considerate that managing a review is a serious commitment; for this reason, it's better to contact the member off-list.
 
-In order to schedule a formal review, the author must find a
- capable volunteer to manage the review. This should be someone
- with knowledge of the library domain, and experience with the
- review process. See [Formal
- Review Process](/community/reviews.html) for the responsibilities of the review
- manager.
+If you cannot find a review manager after three weeks using the means above, and your submission is targeting eventual standardization, there is a list of Boost regulars who are also WG21 committee members who have volunteered to act as review managers in such cases. Try them in the order listed. They are: Zach Laine, Micheal Caisse, Matt Calabrese, Edward Diener, Louis Dionne, Vinnie Falco, Glen Fernandes, and David Sankel.
 
+Once a potential review manager has been identified, contact the xref:managing-reviews.adoc#reviewwizards[Review Wizards] for approval. The wizards approve review managers based on their level of participation in the Boost community.
 
-Authors can find community members interested in managing
- reviews through discussion of the library on the developer
- list. If no one steps forward to volunteer to manage the
- review, it is appropriate to contact an experienced Boost
- member who showed interest in the library. Be considerate that
- managing a review is a serious commitment; for this reason,
- it's better to contact the member off-list.
+The review wizards will coordinate with both the author and review manager to schedule a date convenient for both.
 
+=== Formal Review
 
-If you cannot find a review manager after 3 weeks using the
- means above, and your submission is targeting eventual
- standardization, there is a list of Boost regulars who are also
- WG21 committee members who have volunteered to act as review
- managers in such cases. Please try them in the order listed.
- They are: Zach Laine, Micheal Caisse, Matt Calabrese, Edward
- Diener, Louis Dionne, Vinnie Falco, Glen Fernandes, and David
- Sankel.
+Before your formal review begins, double-, triple-, and quadruple-check your library. Verify that every code example works, that all unit tests pass on at least two compilers on at least two major operating systems, and run your documentation through a spelling and grammar checker.
 
+Please do not modify your library on its master branch during a review. Instead, modify a separate develop branch in response to feedback and reviews. For bigger ticket items of work, open issues on your issue tracker so interested people can track the fixing of specific issues raised.
 
-Once a potential review manager has been identified, [contact the
- review wizards](/community/reviews.html#Wizard) for approval. The wizards approve review
- managers based on their level of participation in the Boost
- community.
+The review manager will consider all the reviews made by members of the community and arrive at a decision on whether your library is rejected, conditionally accepted or unconditionally accepted. They will post a report summarizing the decision publicly. If conditions are attached to acceptance, you will need to implement those conditions or else undergo an additional formal review.
 
+=== Fast Track Reviews
 
-The review wizards will coordinate with both the author and
- review manager to schedule a date convenient for both.
+To qualify for a fast track review:
 
+[disc]
+* The component must be small.
 
-See [Formal Review
- Process](/community/reviews.html) for details.
+* The technique must be already in use in Boost libraries and the new component provides a common implementation.
 
+* A full Boost-conformant implementation is available in the sandbox.
 
-Formal Review
--------------
+* The review wizard determines that the proposal qualifies for fast track review.
 
+==== Fast Track Procedure
 
-Before your formal review begins, double-, triple-, and
- quadruple-check your library. Verify that every code example
- works, that all unit tests pass on at least two compilers on at
- least two major operating systems, and run your documentation
- through a spelling and grammar checker.
+. The Boost review wizard posts a review announcement to the main Boost developer's list. The fast track review period will normally last for 5 days. No two fast-track reviews will run in parallel. Fast track reviews may run during full reviews, though generally, this is to be avoided.
 
+. After the review period ends, the submitter will post a review summary containing proposed changes to the reviewed implementation.
 
-Please do not modify your library on its master branch
- during a review. Instead, modify a separate develop branch in
- response to feedback and reviews. For bigger ticket items of
- work, open issues on your issue tracker so interested people can
- track the fixing of specific issues raised.
+. The review wizard will accept or reject the proposed library and proposed changes.
 
+. After applying the proposed changes, the component is checked into the repository like any other library.
 
-The review manager will consider all the reviews made by
- members of the community and arrive at a decision on
- whether your library is rejected, conditionally accepted or
- unconditionally accepted. They will post a report summarising
- the decision publicly. If conditions are attached to
- acceptance, you will need to implement those conditions or
- else undergo an additional formal review.
+=== Mini-Reviews
 
+It is possible that in the review process some issues might need to be fixed as a _requirement_ for acceptance. If a review does result in conditions on acceptance, the review manager may request a _Mini-Review_, at a later date, to determine if the conditions have been met. The Mini-Review is usually conducted by the same review manager.
 
-Boost web site posting
-----------------------
+=== Boost Website Posting
 
+Once an accepted library is ready for inclusion on the Boost web site, the submitter is typically given Boost repository write access, and expected to check-in and maintain the library there. Contact the moderators if you need write access or direct use of the repository isn't possible for you.
 
-Once an accepted library is ready for inclusion on the Boost
- web site, the submitter is typically given Boost repository
- write access, and expected to check-in and maintain the library
- there. Contact the moderators if you need write access or
- direct use of the repository isn't possible for you.
+=== People Page
 
+If the boost.org web site doesn't already have your capsule biography and picture (optional, with not-too-serious pictures preferred!), please send them to the Boost webmaster. It is up to you as to whether or not the biography includes your email address or other contact information. The preferred picture format is .jpg, but other common formats are acceptable. The preferred image size is 500x375 but the webmaster has photo editing software and can do the image preparation if necessary.
 
-People page
------------
+=== Lifecycle
 
+Libraries are software; they lose their value over time if not maintained. Postings on the Boost developers or users mailing lists can alert you to potential maintenance needs; please plan to maintain your library over time. If you no longer can or wish to maintain your library, please post a message on the Boost developers mailing list asking for a new maintainer to volunteer and then spend the time to help them take over.
 
-If the boost.org web site doesn't already have your capsule
- biography and picture (optional, with not-too-serious pictures
- preferred!), please send them to the Boost webmaster. It is up
- to you as to whether or not the biography includes your email
- address or other contact information. The preferred picture
- format is .jpg, but other common formats are acceptable. The
- preferred image size is 500x375 but the webmaster has photo
- editing software and can do the image preparation if
- necessary.
+Orphaned libraries will be put in the care of a maintenance team, pending a search for a new maintainer.
 
+=== Library Maintainer's Rights and Responsibilities
 
-Lifecycle
----------
+By submitting a library to Boost, you accept responsibility for maintaining your library, or finding a qualified volunteer to serve as maintainer. You must be willing to put your library and documentation under a Boost-compatible license.
 
+You will be expected to respond to reasonable bug reports and questions on time and to participate as needed in discussions of your library on the Boost mailing lists.
 
-Libraries are software; they lose their value over time if
- not maintained. Postings on the Boost developers or users
- mailing lists can alert you to potential maintenance needs;
- please plan to maintain your library over time. If you no
- longer can or wish to maintain your library, please post a
- message on the Boost developers mailing list asking for a new
- maintainer to volunteer and then spend the time to help them
- take over.
+You are free to change your library in any way you wish, and you are encouraged to actively make improvements. However, peer review is an important part of the Boost process and as such you are also encouraged to get feedback from the Boost community before making substantial changes to the interface of an accepted library.
 
+If at some point you no longer wish to serve as maintainer of your library, it is your responsibility to make this known to the Boost community, and to find another individual to take your place.
 
-Orphaned libraries will be put in the care of the [Community
- Maintenance Team](https://svn.boost.org/trac/boost/wiki/CommunityMaintenance).
+Libraries which have been abandoned will be put in care of a maintenance team.
 
+== See Also
 
-
-
-
-
-
-
+* xref:contributor-guide:ROOT:contributors-faq.adoc#security[Contributor Guide FAQ: Security]
+* xref:contributor-guide:ROOT:requirements/library-requirements.adoc[]
 

--- a/formal-reviews/modules/ROOT/pages/writing-reviews.adoc
+++ b/formal-reviews/modules/ROOT/pages/writing-reviews.adoc
@@ -6,11 +6,12 @@ file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 Official repository: https://github.com/boostorg/website-v2-docs
 ////
-= Writing a Review
+= Writing Reviews
+:navtitle: Writing Reviews
 
-The goal of a Boost library review is to improve a candidate library through constructive criticism. At the end a decision must be made: _is the candidate library good enough at this point to accept into Boost?_ If not, we hope to have provided enough constructive criticism for it to be improved and accepted at a later time. The boost:serialization[] library was a good example of how constructive criticism resulted in revisions resulting in an excellent library that was accepted in its second review.
+The goal of a Boost library review is to improve a candidate library through constructive criticism. At the end a decision must be made: _is the candidate library good enough at this point to accept into Boost?_ If not, we hope to have provided enough constructive criticism for it to be improved and accepted at a later time. The boost:serialization[] library is a good example of how constructive criticism resulted in revisions resulting in an excellent library that was accepted in its second review.
 
-Your comments may be brief or lengthy. The Review Manager needs your evaluation of the library. If you identify problems in your evaluation, try to categorize them as _minor_, _serious_, or _showstoppers_.
+Your comments may be brief or lengthy. The review manager needs your evaluation of the library. If you identify problems in your evaluation, try to categorize them as _minor_, _serious_, or _showstoppers_.
 
 Include questions for the library authors. Authors are interested in defending their library. If you don't get a response to your question quickly, be patient; if it takes too long or you don't get an answer you feel is sufficient, ask again or try to rephrase the question. Clarity is important, English is not the native language of many Boost developers.
 

--- a/user-guide/modules/ROOT/pages/release-process.adoc
+++ b/user-guide/modules/ROOT/pages/release-process.adoc
@@ -39,3 +39,4 @@ If issues are found with a release that has gone public, and the issues are impo
 
 For details of the Release Process that are pertinent to contributors, refer to the Contributor Guide xref:contributor-guide:ROOT:release-process.adoc[].
 
+* xref:formal-reviews:ROOT:review-results.adoc[]


### PR DESCRIPTION
fix #183
Reworked the Formal Reviews intro to match the style of User Guide/Contributor Guide. Separated out the Review managers role. Added links as appropriate.