### PR TITLE
Landing pages for Community sections added

### DIFF
--- a/contributor-guide/modules/ROOT/nav.adoc
+++ b/contributor-guide/modules/ROOT/nav.adoc
@@ -61,5 +61,6 @@ Official repository: https://github.com/boostorg/website-v2-docs
 ** xref:release-notes.adoc[]
 
 * Community
+** xref:contributor-community-introduction.adoc[]
 ** xref:tweeting.adoc[]
 ** xref:site-docs-style-guide.adoc[]

--- a/contributor-guide/modules/ROOT/pages/contributor-community-introduction.adoc
+++ b/contributor-guide/modules/ROOT/pages/contributor-community-introduction.adoc
@@ -1,0 +1,28 @@
+////
+Copyright (c) 2024 The C++ Alliance, Inc. (https://cppalliance.org)
+
+Distributed under the Boost Software License, Version 1.0. (See accompanying
+file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+Official repository: https://github.com/boostorg/website-v2-docs
+////
+= Introduction to the Contributor Community
+:navtitle: Introduction
+
+The Boost Contributors Community is a dedicated group of developers and enthusiasts committed to advancing the Boost libraries. There are many different ways of xref:getting-involved.adoc[] with this community.
+
+== Communications
+
+The https://lists.boost.org/mailman/listinfo.cgi/boost[Boost Developers Mailing List] is focused on the development and maintenance of the libraries. It is a platform for proposing new libraries, discussing design and implementation details, and coordinating efforts among contributors. Participation in these mailing lists is open to all. In addition to mailing lists, the Boost community also leverages https://slack.com/[Slack] for real-time communication. The Slack Workspace hosts various channels dedicated to specific libraries, general discussions, and coordination among contributors.
+
+When discussing Boost-related topics on social media, contributors are encouraged to follow our xref:tweeting.adoc[Tweeting] guidelines. These guidelines help ensure that the community maintains a positive and informative presence on social media.
+
+New library developers usually have a lot of questions on their mind, before asking for help or information refer to the xref:contributors-faq.adoc[] for answers to many common questions and dilemmas.
+
+== Documentation Style
+
+A consistent documentation style, that emphasizes readability and accessibility, is encouraged. This includes all the library xref:docs/documentation-guidelines.adoc[Documentation Guidelines] and contributions to this website (refer to xref:site-docs-style-guide.adoc[]).
+
+== See Also
+
+* xref:user-guide:ROOT:user-community-introduction.adoc[]

--- a/user-guide/modules/ROOT/nav.adoc
+++ b/user-guide/modules/ROOT/nav.adoc
@@ -35,6 +35,7 @@ Official repository: https://github.com/boostorg/website-v2-docs
 ** xref:implementation-variations.adoc[]
 
 * Community
+** xref:user-community-introduction.adoc[]
 ** xref:reporting-issues.adoc[]
 ** xref:discussion-policy.adoc[]
 ** xref:bsl.adoc[]

--- a/user-guide/modules/ROOT/pages/user-community-introduction.adoc
+++ b/user-guide/modules/ROOT/pages/user-community-introduction.adoc
@@ -1,0 +1,38 @@
+////
+Copyright (c) 2024 The C++ Alliance, Inc. (https://cppalliance.org)
+
+Distributed under the Boost Software License, Version 1.0. (See accompanying
+file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+Official repository: https://github.com/boostorg/website-v2-docs
+////
+= Introduction to the User Community
+:navtitle: Introduction
+
+The user community is a vibrant and collaborative group dedicated to the use, development, and maintenance of Boost Libraries. Since its inception, Boost has grown to offer a wide range of libraries that address knarly programming tasks, from algorithms and data structures to system utilities and concurrent programming. Boost users are encouraged to chime in with their thoughts and experiences!
+
+== Reporting Issues
+
+Users are encouraged to be active in xref:reporting-issues.adoc[] they encounter with Boost libraries. Users can submit issues directly, providing detailed descriptions, code snippets, and steps to reproduce the problem. This collaboration greatly aids the overall stability and reliability of Boost libraries.
+
+== Boost Mailing Lists
+
+Communication within the Boost community is primarily conducted through mailing lists. The https://lists.boost.org/mailman/listinfo.cgi/boost-users[Boost Users Mailing List] is a forum to ask questions, share experiences, and seeking advice. Participation in the mailing lists is open to all.
+
+=== Discussion Policy
+
+Boost maintains a clear and respectful xref:discussion-policy.adoc[Discussion Policy] to ensure productive and courteous interactions within the community. Participants are expected to engage in constructive dialogue, refrain from personal attacks, and respect differing viewpoints. 
+
+== Boost Software License
+
+The xref:bsl.adoc[Boost Software License (BSL)] is a free, open-source license that permits users to use, modify, and distribute Boost libraries with minimal restrictions. The BSL is designed to be compatible with both open-source and proprietary projects.
+
+== Long History
+
+Boost's long xref:boost-history.adoc[History] is a testament to its enduring relevance and impact. Since its founding in 1998 by the late xref:in-memoriam-beman-dawes.adoc[Beman Dawes], David Abrahams, and Robert Klarer, Boost has been an incubator for cutting-edge pass:[C++] techniques and practices.
+
+Over the years, Boost has grown to include dozens of libraries, each developed and maintained by dedicated contributors from around the world. The libraries are continually updated both to remedy issues and add new features, refer to xref:release-process.adoc[] for the process and cadence of new releases.
+
+== See Also
+
+* xref:contributor-guide:ROOT:contributor-community-introduction.adoc[]


### PR DESCRIPTION
Landing pages for both the User Guide and Contributor Guide have been added to the Community sections, in order for there to be a page that can be linked to from the Learn section of the website. The landing pages include links to all the sections currently under the Community heading.

This is part of solving issue #244