### PR TITLE
remove-sidenav option

### DIFF
--- a/antora-ui/src/helpers/extractKey.js
+++ b/antora-ui/src/helpers/extractKey.js
@@ -1,0 +1,15 @@
+'use strict'
+
+module.exports = (obj, field, options) => {
+  if (!obj) {
+    return obj === null
+  }
+  field = field.split('.')
+  for (let i = 0; i < field.length; i++) {
+    if (!Object.prototype.hasOwnProperty.call(obj, field[i])) {
+      return undefined
+    }
+    obj = obj[field[i]]
+  }
+  return obj
+}

--- a/antora-ui/src/helpers/json.js
+++ b/antora-ui/src/helpers/json.js
@@ -1,0 +1,7 @@
+'use strict'
+
+module.exports = (...args) => {
+  const numArgs = args.length
+  if (numArgs !== 2) throw new Error('{{json}} helper expects 1 argument')
+  return JSON.stringify(args[0], null, 2)
+}

--- a/antora-ui/src/helpers/siteStartPage.js
+++ b/antora-ui/src/helpers/siteStartPage.js
@@ -1,0 +1,7 @@
+'use strict'
+
+module.exports = ({
+  data: {
+    root: { contentCatalog = { getSiteStartPage () {} } },
+  },
+}) => contentCatalog.getSiteStartPage()

--- a/antora-ui/src/partials/article.hbs
+++ b/antora-ui/src/partials/article.hbs
@@ -1,7 +1,12 @@
 <article class="doc">
-{{#with page.title}}
-<h1 class="page">{{{this}}}</h1>
-{{/with}}
-{{{page.contents}}}
-{{> pagination}}
+  {{#with page.title}}
+    <h1 class="page">{{{this}}}</h1>
+  {{/with}}
+  {{#if (ne page.component.latest.asciidoc.attributes.remove-sidenav undefined)}}
+    {{#if (and (eq page.module 'ROOT') (eq page.relativeSrcPath (or (extractKey (siteStartPage) 'asciidoc.attributes.page-relative-src-path') 'index.adoc')))}}
+      {{> nav-tree-plain navigation=page.navigation}}
+    {{/if}}
+  {{/if}}
+  {{{page.contents}}}
+  {{> pagination}}
 </article>

--- a/antora-ui/src/partials/body.hbs
+++ b/antora-ui/src/partials/body.hbs
@@ -1,4 +1,6 @@
 <div class="body">
-{{> nav}}
+{{#if (eq page.component.latest.asciidoc.attributes.remove-sidenav undefined)}}
+  {{> nav}}
+{{/if}}
 {{> main}}
 </div>

--- a/antora-ui/src/partials/head-info.hbs
+++ b/antora-ui/src/partials/head-info.hbs
@@ -1,20 +1,20 @@
-    {{#with page.canonicalUrl}}
-    <link rel="canonical" href="{{{this}}}">
-    {{/with}}
-    {{#unless (eq page.attributes.pagination undefined)}}
-    {{#with page.previous}}
+{{#with page.canonicalUrl}}
+  <link rel="canonical" href="{{{this}}}">
+{{/with}}
+{{#unless (eq page.attributes.pagination undefined)}}
+  {{#with page.previous}}
     <link rel="prev" href="{{{relativize ./url}}}">
-    {{/with}}
-    {{#with page.next}}
+  {{/with}}
+  {{#with page.next}}
     <link rel="next" href="{{{relativize ./url}}}">
-    {{/with}}
-    {{/unless}}
-    {{#with page.description}}
-    <meta name="description" content="{{{detag this}}}">
-    {{/with}}
-    {{#with page.keywords}}
-    <meta name="keywords" content="{{{this}}}">
-    {{/with}}
-    {{#with (or antoraVersion site.antoraVersion)}}
-    <meta name="generator" content="Antora {{{this}}}">
-    {{/with}}
+  {{/with}}
+{{/unless}}
+{{#with page.description}}
+  <meta name="description" content="{{{detag this}}}">
+{{/with}}
+{{#with page.keywords}}
+  <meta name="keywords" content="{{{this}}}">
+{{/with}}
+{{#with (or antoraVersion site.antoraVersion)}}
+  <meta name="generator" content="Antora {{{this}}}">
+{{/with}}

--- a/antora-ui/src/partials/main.hbs
+++ b/antora-ui/src/partials/main.hbs
@@ -1,11 +1,13 @@
 <main class="article">
-{{> toolbar}}
+  {{> toolbar}}
   <div class="content">
-{{#if (eq page.layout '404')}}
-{{> article-404}}
-{{else}}
-{{> toc}}
-{{> article}}
-{{/if}}
+    {{#if (eq page.layout '404')}}
+      {{> article-404}}
+    {{else}}
+      {{#if (eq page.component.latest.asciidoc.attributes.remove-sidenav undefined)}}
+        {{> toc}}
+      {{/if}}
+      {{> article}}
+    {{/if}}
   </div>
 </main>

--- a/antora-ui/src/partials/nav-menu.hbs
+++ b/antora-ui/src/partials/nav-menu.hbs
@@ -2,7 +2,7 @@
 <div class="nav-panel-menu is-active" data-panel="menu">
   <nav class="nav-menu">
     {{#with @root.page.componentVersion}}
-    <h3 class="title"><a href="{{{relativize ./url}}}">{{./title}}</a></h3>
+      <h3 class="title"><a href="{{{relativize ./url}}}">{{./title}}</a></h3>
     {{/with}}
     {{> nav-tree navigation=this}}
   </nav>

--- a/antora-ui/src/partials/nav-tree-plain.hbs
+++ b/antora-ui/src/partials/nav-tree-plain.hbs
@@ -1,0 +1,18 @@
+{{#if navigation.length}}
+  <ul>
+    {{#each navigation}}
+      {{#if ./content}}
+        <li class="{{#if (eq ./url @root.page.url)}} is-current-page{{/if}}" data-depth="{{or ../level 0}}">
+          {{#if ./url}}
+            <a class="nav-link" href="
+              {{~#if (eq ./urlType 'internal')}}{{{relativize ./url}}}
+              {{~else}}{{{./url}}}{{~/if}}">{{{./content}}}</a>
+          {{else}}
+            <span class="nav-text">{{{./content}}}</span>
+          {{/if}}
+        </li>
+      {{/if}}
+      {{> nav-tree-plain navigation=./items level=(increment ../level)}}
+    {{/each}}
+  </ul>
+{{/if}}

--- a/antora-ui/src/partials/nav-tree.hbs
+++ b/antora-ui/src/partials/nav-tree.hbs
@@ -1,21 +1,21 @@
 {{#if navigation.length}}
-<ul class="nav-list">
-  {{#each navigation}}
-  <li class="nav-item{{#if (eq ./url @root.page.url)}} is-current-page{{/if}}" data-depth="{{or ../level 0}}">
-    {{#if ./content}}
-    {{#if ./items.length}}
-    <button class="nav-item-toggle"></button>
-    {{/if}}
-    {{#if ./url}}
-    <a class="nav-link" href="
-      {{~#if (eq ./urlType 'internal')}}{{{relativize ./url}}}
-      {{~else}}{{{./url}}}{{~/if}}">{{{./content}}}</a>
-    {{else}}
-    <span class="nav-text">{{{./content}}}</span>
-    {{/if}}
-    {{/if}}
-{{> nav-tree navigation=./items level=(increment ../level)}}
-  </li>
-  {{/each}}
-</ul>
+  <ul class="nav-list">
+    {{#each navigation}}
+      <li class="nav-item{{#if (eq ./url @root.page.url)}} is-current-page{{/if}}" data-depth="{{or ../level 0}}">
+        {{#if ./content}}
+          {{#if ./items.length}}
+            <button class="nav-item-toggle"></button>
+          {{/if}}
+          {{#if ./url}}
+          <a class="nav-link" href="
+            {{~#if (eq ./urlType 'internal')}}{{{relativize ./url}}}
+            {{~else}}{{{./url}}}{{~/if}}">{{{./content}}}</a>
+          {{else}}
+            <span class="nav-text">{{{./content}}}</span>
+          {{/if}}
+        {{/if}}
+        {{> nav-tree navigation=./items level=(increment ../level)}}
+      </li>
+    {{/each}}
+  </ul>
 {{/if}}

--- a/libs.playbook.yml
+++ b/libs.playbook.yml
@@ -48,6 +48,10 @@ asciidoc:
     page-boost-ui-branch: develop
     page-boost-is-release: ''
     page-commit-id: ''
+    # Enable pagination
+    page-pagination: ''
+    # Remove the sidenav and include TOC in index.adoc page
+    remove-sidenav: ''
   extensions:
     - ./extensions/boost-link-inline-macro.js
     - '@asciidoctor/tabs'

--- a/site.playbook.yml
+++ b/site.playbook.yml
@@ -36,7 +36,10 @@ antora:
     - require: ./extensions/boost.js
 asciidoc:
   attributes:
+    # Enable pagination
     page-pagination: ''
+    # Remove the sidenav and include TOC in index.adoc page
+    remove-sidenav: ''
   extensions:
     - ./extensions/boost-link-inline-macro.js
     - '@asciidoctor/tabs'


### PR DESCRIPTION
This PR updates the UI bundle to recognize the remove-sidenav option. When the option is enabled, the nav and sidebar are removed, and the main page of each component includes the ToC. In other words, it looks more like the Boost quickbook documentation.