### PR TITLE
sitedoc.sh uses bash var. substring

### DIFF
--- a/sitedoc.sh
+++ b/sitedoc.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Copyright (c) 2024 The C++ Alliance, Inc. (https://cppalliance.org)
 #
@@ -12,6 +12,11 @@
 # This script is used to build the site
 # documentation which is not tagged per release.
 #
+
+# Note: macos users, run these commands
+# brew install findutils
+# echo "export PATH=\"/opt/homebrew/opt/findutils/libexec/gnubin:\$PATH\"" >> ~/.zprofile
+# . ~/.zprofile
 
 if [ $# -eq 0 ]; then
   echo "Usage: $0 { 'develop' | 'master' }..."
@@ -67,7 +72,7 @@ fi
 # Identify current commit id for footer
 if command -v git >/dev/null && git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   commit_id=$(git rev-parse HEAD)
-  commit_id=$(expr substr "$commit_id" 1 7)
+  commit_id=$(echo ${commit_id:0:7})
 else
   commit_id=""
 fi


### PR DESCRIPTION
This PR changes a line in sitedoc.sh to support macOS .  Requires bash shell.  

@alandefreitas , the web developers faced some confusion when following the README instructions.  Consider this section: 

```
./sitedoc.sh develop
./sitedoc.sh master
Site generation complete!
Open file:///home/user/path/to/antora/build/develop/doc in a browser to view your site.
Site generation complete!
Open file:///home/user/path/to/antora/build/doc in a browser to view your site.

```
Question 1: maybe it should it say this instead? (not sure, see next question also.)  

./sitedoc.sh develop
\# or 
./sitedoc.sh master

They were running exactly what was written. Both commands:  

./sitedoc.sh develop
./sitedoc.sh master

Question 2:  

The contents of the S3 bucket has a master/ and a develop/ subdirectory. Notice in the example output there is coincidentally a path "build/develop".     It makes it seem like there will be output in "build/master" and "build/develop", which matches what should be uploaded to S3.    But in fact, that may be a coincidence, and really the sitedoc.sh output simply goes into "build".    It may be not-obvious to write this sentence "path to antora build docs" in the format of a directory listing "/path/to/antora/build/develop/doc".  It could more realistically say "/home/user/website-v2-docs/build".  Will both master and develop builds go into the build directory, overwriting each other?  Or, do master and develop builds have separate destination directories? what are they, by default?  Are they overwriting each other, both in build/  ?

