### PR TITLE
change to fix build error

### DIFF
--- a/user-guide/modules/ROOT/pages/intro.adoc
+++ b/user-guide/modules/ROOT/pages/intro.adoc
@@ -76,7 +76,7 @@ The current Boost libraries are categorized as follows (the count shows the numb
 |String and text processing | 14 | Covers type conversion, string formatting, streams, localization, regular expressions, parsing, string algorithms, tokens.
 |System | 11 | Time utilities, context switching, handling libraries, threads, a smart file system, processes, backtraces, errors.
 |Template Metaprogramming | 15 | Libraries to support the development of libraries, with features such as callable traits, reflection, function types, tuples, higher-order functions, parsing, sequences, metafunctions, static assertions, introspection, properties, expressions.
-|Miscellaneous | Libraries for numerical type and text conversion, byte ordering, logging, swapping, timing, initialization, and other utilities.
+|Miscellaneous | ? | Libraries for numerical type and text conversion, byte ordering, logging, swapping, timing, initialization, and other utilities.
 |===
 
 


### PR DESCRIPTION
fixes a year old issue that breaks the build.

Will need input as to what the actual value should be. @PeterTurcan originally made the commit, so perhaps he knows what the actual value should be.

In the user-guide/modules/ROOT/pages/intro.adoc line 79 it shows:
|Miscellaneous | Libraries for numerical type and text conversion, byte ordering, logging, swapping, timing, initialization, and other utilities.
It should have a number after the first pipe like this, as all the others have them
`|System | 11 | Time utilities, context switching, handling libraries, threads, a smart file system, processes, backtraces, errors.`
changing the line to
|Miscellaneous | ? | Libraries for numerical type and text conversion, byte ordering, logging, swapping, timing, initialization, and other utilities.
solves the problem, but it would be good to know the actual quantity.