### PR TITLE
mobile vertical alignment fix

### DIFF
--- a/antora-ui/src/css/antora-ui.css
+++ b/antora-ui/src/css/antora-ui.css
@@ -100,7 +100,8 @@ html:not(.is-clipped--nav) main.article {
 
 @media screen and (max-width: 770px) {
   .card {
-    position: absolute;
+    position: absolute !important;
+    top: 2.7rem;
   }
 }
 
@@ -182,14 +183,14 @@ html.is-clipped--nav .nav-close {
   outline: none;
   line-height: inherit;
   padding: 0;
-  height: 3rem;
+  height: 2rem;
   width: 3rem;
   margin-right: -0.25rem;
 }
 
 .nav-container.is-active {
   position: static;
-  padding: 1rem;
+  padding: 0.5rem 1rem;
 }
 
 @media screen and (min-width: 769px) {


### PR DESCRIPTION
In mobile view, the antora docs were being covered by the nav bar. This PR fixes it.