### PR TITLE
Nav and responsive layout fixes

### DIFF
--- a/antora-ui/preview-src/ui-model.yml
+++ b/antora-ui/preview-src/ui-model.yml
@@ -54,6 +54,7 @@ site:
     latestVersion: *latest_version_123
 page:
   url: *home_url
+  role: -toc
   home: true
   title: Brand&#8217;s Hardware &amp; Software Requirements
   component: *component

--- a/antora-ui/src/css/antora-ui.css
+++ b/antora-ui/src/css/antora-ui.css
@@ -12,28 +12,23 @@
   --max-width: 80rem;
 }
 
-html.is-clipped--nav {
-  overflow-y: visible;
+html,
+body {
+  height: 100%;
+  min-height: 100vh;
 }
 
-.body {
-  max-width: var(--max-width);
-  margin-left: auto;
-  margin-right: auto;
+html.is-clipped--nav {
+  overflow-y: visible;
 }
 
 @media screen and (min-width: 769px) {
   .body {
     display: flex;
-    gap: 1rem;
-    padding: 1rem;
-  }
-}
-
-@media screen and (min-width: 1024px) {
-  .body {
-    display: flex;
-    padding: 1rem;
+    padding-top: 1rem;
+    padding-right: 1rem;
+    padding-bottom: 0;
+    padding-left: 1rem;
   }
 }
 
@@ -53,6 +48,7 @@ body.article {
 
 /* Document Styles */
 main.article {
+  padding-bottom: 0;
   min-width: 0;
 }
 
@@ -70,20 +66,33 @@ html:not(.is-clipped--nav) main.article {
   padding: 1rem 1rem 4rem;
 }
 
+@media screen and (max-width: 768px) {
+  .content {
+    width: 100%;
+  }
+}
+
+@media screen and (min-width: 769px) {
+  main.article {
+    padding-left: 1rem;
+  }
+}
+
 @media screen and (min-width: 1024px) {
   .doc {
     margin: 0;
   }
+}
 
-  .content {
-    gap: 1rem;
+@media screen and (min-width: 1820px) {
+  main.article {
+    padding-left: 1rem;
   }
 }
 
 /* Card Styles */
 .card {
   background-color: var(--color-white);
-  position: relative;
 }
 
 .dark .card {
@@ -98,17 +107,13 @@ html:not(.is-clipped--nav) main.article {
   }
 }
 
-@media screen and (max-width: 768px) {
-  .card {
-    position: absolute !important;
-    top: 2.7rem;
-  }
-}
-
 /* Navigation Styles */
 aside.nav {
+  position: initial;
   background-color: var(--color-white);
+  box-shadow: none;
   height: auto;
+  overflow-y: auto;
 }
 
 .dark aside.nav,
@@ -121,13 +126,8 @@ html.is-clipped--nav .nav-close {
   visibility: visible;
 }
 
-.nav {
-  position: initial;
-  box-shadow: none;
-}
-
 .nav .panels {
-  height: 100%;
+  height: auto;
 }
 
 .nav-list {
@@ -156,20 +156,6 @@ html.is-clipped--nav .nav-close {
   visibility: hidden;
 }
 
-@media screen and (min-width: 769px) {
-  .nav-toggle {
-    display: none;
-    visibility: hidden;
-  }
-}
-
-@media screen and (min-width: 769px) {
-  .nav-toggle.is-active ~ .spirit-nav {
-    display: block;
-    visibility: visible;
-  }
-}
-
 .nav-toggle {
   background-position-x: 0;
   background-position-y: 50%;
@@ -188,23 +174,14 @@ html.is-clipped--nav .nav-close {
   margin-right: -0.25rem;
 }
 
-.nav-container.is-active {
-  position: static;
-  padding: 0.5rem 1rem;
+.dark .nav-close {
+  background: url(../img/dark-back.svg) 0% 40% no-repeat;
+  background-size: 41.5%;
 }
 
-@media screen and (min-width: 769px) {
-  .nav-container {
-    position: static;
-    visibility: visible;
-    flex: 0 0 20%;
-    min-width: 14rem;
-  }
-
-  .nav-container.is-active {
-    padding-left: 1rem;
-    padding-top: 1rem;
-  }
+.nav-container.is-active {
+  position: static;
+  padding: 0.5rem 1rem 2rem;
 }
 
 .nav-menu a,
@@ -213,16 +190,44 @@ html.is-clipped--nav .nav-close {
   color: var(--color-black);
 }
 
+@media screen and (min-width: 769px) {
+  .nav-toggle {
+    display: none;
+    visibility: hidden;
+  }
+
+  .nav-toggle.is-active ~ .spirit-nav {
+    display: block;
+    visibility: visible;
+  }
+
+  .nav-container {
+    position: sticky;
+    top: 1rem;
+    bottom: 1rem;
+    left: 1rem;
+    height: calc(100vh - 2rem);
+    visibility: visible;
+    min-width: 16rem;
+    overflow-y: auto;
+    font-size: 1rem !important;
+  }
+
+  .nav-container.is-active {
+    padding-left: 1rem;
+    padding-top: 1rem;
+  }
+}
+
 /* Toolbar Styles */
 .toolbar {
   background-color: #fff;
   box-shadow: unset;
   height: 2rem;
-  top: 3px !important;
-  position: absolute;
+  position: static;
   display: flex;
   justify-content: space-between;
-  width: 96%;
+  width: 100%;
 }
 
 .dark div.toolbar {
@@ -321,4 +326,10 @@ nav.pagination {
 nav.pagination a::after,
 nav.pagination a::before {
   width: 0.75rem;
+}
+
+.topnavbar + div.body {
+  margin-left: auto;
+  margin-right: auto;
+  max-width: 80rem;
 }

--- a/antora-ui/src/css/toolbar.css
+++ b/antora-ui/src/css/toolbar.css
@@ -28,6 +28,18 @@
   margin-right: -0.25rem;
 }
 
+.dark .nav-toggle {
+  background: url(../img/dark-menu.svg) no-repeat 50% 47.5%;
+  background-size: 49%;
+  border: none;
+  outline: none;
+  line-height: inherit;
+  padding: 0;
+  height: var(--toolbar-height);
+  width: var(--toolbar-height);
+  margin-right: -0.25rem;
+}
+
 @media screen and (min-width: 1024px) {
   .nav-toggle {
     display: none;

--- a/antora-ui/src/img/dark-back.svg
+++ b/antora-ui/src/img/dark-back.svg
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+ xmlns:dc="http://purl.org/dc/elements/1.1/"
+ xmlns:cc="http://creativecommons.org/ns#"
+ xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+ xmlns:svg="http://www.w3.org/2000/svg"
+ xmlns="http://www.w3.org/2000/svg"
+ xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+ xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+ width="100"
+ height="100"
+ viewBox="0 0 100 100"
+ version="1.1"
+ inkscape:version="0.92.2 (5c3e80d, 2017-08-06)"
+ sodipodi:docname="dark-back.svg"
+ enable-background="new">
+<title>Left arrow</title>
+<sodipodi:namedview
+ pagecolor="#ffffff"
+ bordercolor="#dddddd"
+ borderopacity="1.0"
+ inkscape:pageopacity="0.0"
+ inkscape:pageshadow="2"
+ inkscape:zoom="6.108138"
+ inkscape:cx="21.142679"
+ inkscape:cy="42.629076"
+ inkscape:document-units="px"
+ inkscape:current-layer="layer1"
+ showgrid="false"
+ units="px"
+ fit-margin-top="0"
+ fit-margin-left="0"
+ fit-margin-right="0"
+ fit-margin-bottom="0"
+ inkscape:window-width="1920"
+ inkscape:window-height="1001"
+ inkscape:window-x="0"
+ inkscape:window-y="41"
+ inkscape:window-maximized="1"
+ scale-x="1" />
+<metadata>
+<rdf:RDF>
+<cc:Work
+ rdf:about="">
+<dc:format>image/svg+xml</dc:format>
+<dc:type
+ rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+<dc:title>Left arrow</dc:title>
+<dc:creator>
+<cc:Agent>
+<dc:title>Sarah White</dc:title>
+</cc:Agent>
+</dc:creator>
+<dc:publisher>
+<cc:Agent>
+<dc:title>OpenDevise Inc.</dc:title>
+</cc:Agent>
+</dc:publisher>
+<cc:license
+ rdf:resource="http://creativecommons.org/licenses/by-sa/4.0/" />
+</cc:Work>
+<cc:License
+ rdf:about="http://creativecommons.org/licenses/by-sa/4.0/">
+<cc:permits
+ rdf:resource="http://creativecommons.org/ns#Reproduction" />
+<cc:permits
+ rdf:resource="http://creativecommons.org/ns#Distribution" />
+<cc:requires
+ rdf:resource="http://creativecommons.org/ns#Notice" />
+<cc:requires
+ rdf:resource="http://creativecommons.org/ns#Attribution" />
+<cc:permits
+ rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+<cc:requires
+ rdf:resource="http://creativecommons.org/ns#ShareAlike" />
+</cc:License>
+</rdf:RDF>
+</metadata>
+<g
+ transform="translate(-3.926492e-7,-270.54187)">
+<path fill="#dddddd"
+ d="m 50.000978,280.44162 -40.1010516,40.10025 40.1010516,40.10025 5.6556,-5.65551 -30.434757,-30.44194 h 64.878253 v -8.0056 H 25.221821 l 30.434757,-30.44001 z" />
+</g>
+</svg>

--- a/antora-ui/src/img/dark-menu.svg
+++ b/antora-ui/src/img/dark-menu.svg
@@ -1,0 +1,158 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   x="0px"
+   y="0px"
+   viewBox="0 0 100 100"
+   id="svg2"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="menu.svg">
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10">
+    <inkscape:path-effect
+       is_visible="true"
+       id="path-effect4225"
+       effect="spiro" />
+    <inkscape:path-effect
+       effect="spiro"
+       id="path-effect4221"
+       is_visible="true" />
+    <inkscape:path-effect
+       effect="spiro"
+       id="path-effect4213"
+       is_visible="true" />
+    <inkscape:path-effect
+       is_visible="true"
+       id="path-effect4209"
+       effect="spiro" />
+    <inkscape:path-effect
+       effect="spiro"
+       id="path-effect4204"
+       is_visible="true" />
+    <inkscape:path-effect
+       is_visible="true"
+       id="path-effect4191"
+       effect="spiro" />
+    <inkscape:path-effect
+       effect="spiro"
+       id="path-effect4187"
+       is_visible="true" />
+    <inkscape:path-effect
+       effect="spiro"
+       id="path-effect4183"
+       is_visible="true" />
+    <inkscape:path-effect
+       is_visible="true"
+       id="path-effect4179"
+       effect="spiro" />
+    <inkscape:path-effect
+       effect="spiro"
+       id="path-effect4173"
+       is_visible="true" />
+    <inkscape:path-effect
+       is_visible="true"
+       id="path-effect4169"
+       effect="spiro" />
+    <inkscape:path-effect
+       effect="spiro"
+       id="path-effect4165"
+       is_visible="true" />
+  </defs>
+  <sodipodi:namedview
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1406"
+     id="namedview8"
+     showgrid="false"
+     inkscape:zoom="5.76"
+     inkscape:cx="14.532031"
+     inkscape:cy="43.425849"
+     inkscape:window-x="0"
+     inkscape:window-y="1440"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g4" />
+  <g
+     transform="translate(0,-952.36218)"
+     id="g4">
+    <g
+       id="g4238"
+       transform="translate(-1.5e-6,-0.2053541)">
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path4149"
+         d="m 35,972.34003 55.000003,0"
+         style="fill:none;fill-rule:evenodd;stroke:#ddd;stroke-width:8;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.94117647" />
+      <rect
+         y="964.84003"
+         x="10"
+         height="15"
+         width="15"
+         id="rect4184"
+         style="opacity:1;fill:#ddd;fill-opacity:1;stroke:none;stroke-width:10;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         style="fill:none;fill-rule:evenodd;stroke:#ddd;stroke-width:5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.94117647"
+         d="m 42.999999,1016.2452 44.999999,0"
+         id="path4180"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc" />
+      <rect
+         style="opacity:1;fill:#ddd;fill-opacity:1;stroke:none;stroke-width:10;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="rect4186"
+         width="10"
+         height="10"
+         x="23"
+         y="1011.2452" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path4182"
+         d="m 42.999999,1035.295 44.999999,0"
+         style="fill:none;fill-rule:evenodd;stroke:#ddd;stroke-width:5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.94117647" />
+      <rect
+         y="1030.295"
+         x="23"
+         height="10"
+         width="10"
+         id="rect4188"
+         style="opacity:1;fill:#ddd;fill-opacity:1;stroke:none;stroke-width:10;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path4210"
+         d="m 42.999999,997.1955 44.999999,0"
+         style="fill:none;fill-rule:evenodd;stroke:#ddd;stroke-width:5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.94117647" />
+      <rect
+         y="992.1955"
+         x="23"
+         height="10"
+         width="10"
+         id="rect4212"
+         style="opacity:1;fill:#ddd;fill-opacity:1;stroke:none;stroke-width:10;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
This PR allows the side navigation to scroll independently from the article content.

Fixes #293 

**Note:** There’s a bug where at 769 and 770 pixels wide, the nav’s position is off. This fix will be included in upcoming  PRs
