### PR TITLE
Add Writing to Documentation heading

### DIFF
--- a/contributor-guide/modules/ROOT/nav.adoc
+++ b/contributor-guide/modules/ROOT/nav.adoc
@@ -50,7 +50,7 @@ Official repository: https://github.com/boostorg/website-v2-docs
 ** xref:superproject/library-maintenance.adoc[]
 ** xref:superproject/library-workflow.adoc[]
 
-* Documentation
+* Writing Documentation
 ** xref:docs/documentation-guidelines.adoc[]
 ** xref:docs/documentation-components.adoc[]
 ** xref:docs/antora.adoc[Antora Guide]


### PR DESCRIPTION
fix #269 

@julioest Agree on making the heading active - "Writing Documentation". Currently all the nodes in both the CG and UG are not links to documents, they just open and close the content sections within them. This is the current style (see Microsoft docs for example).  However, if we prefer to have nodes also as links, then all of the nodes would have to also be links within our guides. Agreed this is a style issue and can go either way, but I prefer not linking nodes for its lack of ambiguity.