### PR TITLE
build: update cpp reference extension

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,6 +27,7 @@ jobs:
         include:
           - { name: 'Ubuntu', os: ubuntu-22.04, publish: true }
           - { name: 'Windows', os: windows-2022 }
+          - { name: 'MacOS', os: macos-latest }
     name: Publish Antora Docs (${{ matrix.name }})
     runs-on: ${{ matrix.os }}
     steps:
@@ -57,18 +58,20 @@ jobs:
               changed_ext=$(echo "$changed_files" | grep -q "extensions/" && echo true || echo false)
               changed_actions=$(echo "$changed_files" | grep -q ".github/" && echo true || echo false)
               changed_libs=$(echo "$changed_files" | grep -q "libs.playbook.yml" && echo true || echo false)
+              changed_packages=$(echo "$changed_files" | grep -q "package.json" && echo true || echo false)
           else
               # Assume anything might have changed
               changed_ui=true
               changed_ext=true
               changed_actions=true
               changed_libs=true
+              changed_packages=true
           fi
           
           set -x
           
           # Only build lib playbook if it changed
-          if [ "$changed_ui" = true ] || [ "$changed_ext" = true ] || [ "$changed_libs" = true ] || [ "$changed_actions" = true ]; then
+          if [ "$changed_ui" = true ] || [ "$changed_ext" = true ] || [ "$changed_libs" = true ] || [ "$changed_actions" = true ] || [ "$changed_packages" = true ]; then
               echo "build-libs=true" >> $GITHUB_OUTPUT
           else
               echo "build-libs=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,6 +30,9 @@ jobs:
           - { name: 'MacOS', os: macos-latest }
     name: Publish Antora Docs (${{ matrix.name }})
     runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -89,11 +92,29 @@ jobs:
         uses: seanmiddleditch/gha-setup-ninja@v4
         if: ${{ runner.os == 'Windows' && steps.build.outputs.build-libs == 'true' }}
 
+      - name: Identify Boost Modules
+        if: steps.build.outputs.build-libs == 'true'
+        run: |
+          grep -o 'https://github.com/boostorg/[a-zA-Z0-9_-]*' libs.playbook.yml | sed 's/https:\/\/github.com\/boostorg\///' | grep -v -e 'website-v2-docs' -e 'boost' | tr '\n' ' ' > boost_modules.txt
+          boost_modules=$(cat boost_modules.txt)
+          echo "boost-modules=$boost_modules" >> $GITHUB_OUTPUT
+        id: boost-modules
+
+      - name: Clone Boost
+        uses: alandefreitas/cpp-actions/boost-clone@v1.8.7
+        if: steps.build.outputs.build-libs == 'true'
+        id: boost-clone
+        with:
+          branch: ${{ (github.ref_name == 'master' && github.ref_name) || 'develop' }}
+          modules: ${{ steps.boost-modules.outputs.boost-modules }}
+
       - name: Build Libs
         if: steps.build.outputs.build-libs == 'true'
         shell: bash
         run: |
           set -x
+          BOOST_SRC_DIR="${{ steps.boost-clone.outputs.boost-dir }}"
+          export BOOST_SRC_DIR
           ./libdoc.sh "${{ (startsWith(github.ref, 'refs/heads/develop') && 'develop') || 'master' }}"
           
       - name: Remove Libs from build

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
       "dependencies": {
         "@antora/lunr-extension": "^1.0.0-alpha.8",
         "@asciidoctor/tabs": "^1.0.0-beta.3",
-        "@cppalliance/antora-cpp-reference-extension": "^0.0.4",
+        "@cppalliance/antora-cpp-reference-extension": "^0.0.5",
         "@cppalliance/antora-cpp-tagfiles-extension": "^0.0.4",
         "@cppalliance/antora-playbook-macros-extension": "^0.0.2",
         "@cppalliance/asciidoctor-boost-links": "^0.0.2"
@@ -47,9 +47,9 @@
       }
     },
     "node_modules/@cppalliance/antora-cpp-reference-extension": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/@cppalliance/antora-cpp-reference-extension/-/antora-cpp-reference-extension-0.0.4.tgz",
-      "integrity": "sha512-S/jqpNXq0it3YvUaMAo+mfD13Q7YbmzBsFKwGDh4rjbrwOI7FPHrCMQZBwO3lz96MIMLlOhk5s/n8al8iyLO5Q==",
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@cppalliance/antora-cpp-reference-extension/-/antora-cpp-reference-extension-0.0.5.tgz",
+      "integrity": "sha512-wSJgtb6FF/s3n9ex7HT7dFHimzaLLvkcNsy0CtL74chOGnAXbQlmuK5Jfw0BvgkdBtaazekgRC4lh/Gktw2aFw==",
       "dependencies": {
         "@antora/expand-path-helper": "^2.0.0",
         "axios": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@cppalliance/antora-cpp-reference-extension": "^0.0.4",
+    "@cppalliance/antora-cpp-reference-extension": "^0.0.5",
     "@cppalliance/antora-cpp-tagfiles-extension": "^0.0.4",
     "@cppalliance/antora-playbook-macros-extension": "^0.0.2",
     "@cppalliance/asciidoctor-boost-links": "^0.0.2",


### PR DESCRIPTION
- Update cpp-reference extension to 0.0.5, which supports macOS
- Add MacOS to the CI matrix
- Add a CI step to identify modules in the libs playbook and modify the clone step to only clone these modules

@julioest With this PR, you can also build the libs playbook on MacOS without a container. The MrDocs binaries are for MacOS 15, though.