### PR TITLE
Short Safe C++ section added to Contributor Guide

### DIFF
--- a/contributor-guide/modules/ROOT/pages/contributors-faq.adoc
+++ b/contributor-guide/modules/ROOT/pages/contributors-faq.adoc
@@ -305,8 +305,16 @@ Clearly there could be significant interest in safe versions of Boost libraries,
 Both the stakes and the workloads are high! If the proposal leads to a solid set of extensions, then as a library developer you will have a decision to make - whether to refactor your library using these extensions, or not. Many factors might influence this decision.
 
 . *Is Safe C++ part of Boost?*
++
+No, it is an independent initiative. The pass:[C++] Alliance has partnered with Sean Baxter, a key proponent of Safe pass:[C++], to further develop the proposal, and seek feedback from developers, researchers, and other stakeholders to refine the project's scope.
 
-No, it is an independent initiative.
+. *Is there an official release schedule for Safe C++?*
++
+No, it is still at the proposal and design refinement stage.
+
+. *What kind of feedback has the proposal garnered so far?*
++
+Positive feedback centers on appreciation of the initiative to address longstanding safety concerns in pass:[C++]. More challenging feedback has included concerns about the complexity of integrating new safety features into the existing pass:[C++] framework, balancing enhanced safety with the language's core design features of performance and flexibility, and competition from the https://www.rust-lang.org/[RUST] language.
 
 [[security]]
 == Security

--- a/contributor-guide/modules/ROOT/pages/contributors-faq.adoc
+++ b/contributor-guide/modules/ROOT/pages/contributors-faq.adoc
@@ -20,6 +20,7 @@ This section contains answers to the common questions that new contributors to B
 * <<Existing Boost Libraries>>
 * <<Modular Boost>>
 * <<Post-Release Engagement>>
+* <<Safe C++>>
 * <<Security>>
 * <<Testing>>
 
@@ -292,6 +293,20 @@ Positive feedback and praise from developers not only encourages the library aut
 +
 Financial contributions or sponsorships as a token of appreciation are rare!
 
+[[safecpp]]
+== Safe C++
+
+. *As a contributor of a library to Boost, what do I need to know about Safe pass:[C++]?*
++
+Currently, https://safecpp.org/P3390R0.html[Safe pass:[C++]] is a proposal, under discussion, to develop a memory-safe set of extensions to pass:[C++]. The push is because the current lack of memory safety makes it too easy for malicious software to exploit language vulnerabilities and perform a variety of attacks. Safe pass:[C++] would provide robust memory-safe, type-safe, and thread-safe operations.
++
+Clearly there could be significant interest in safe versions of Boost libraries, though the level of work involved extends well beyond rewriting a library using the safe extensions, as _all_ dependencies would also have to be safe versions too.
++
+Both the stakes and the workloads are high! If the proposal leads to a solid set of extensions, then as a library developer you will have a decision to make - whether to refactor your library using these extensions, or not. Many factors might influence this decision.
+
+. *Is Safe C++ part of Boost?*
+
+No, it is an independent initiative.
 
 [[security]]
 == Security


### PR DESCRIPTION
Current Safe Cpp status summarized for contributors, and link provided, and makes clear this is not a Boost initiative.