### PR TITLE
chore: update highlight.js to v11.9.0 and optimize syntax highlighting

### DIFF
--- a/antora-ui/gulp.d/tasks/build.js
+++ b/antora-ui/gulp.d/tasks/build.js
@@ -178,11 +178,16 @@ function getAllTasks (opts, sourcemaps, postcssPlugins, preview, src) {
     // Task for processing CSS files
     // NOTE use the next line to bundle a JavaScript library that cannot be browserified, like jQuery
     //vfs.src(require.resolve('<package-name-or-require-path>'), opts).pipe(concat('js/vendor/<library-name>.js')),
-    vfs.src('css/boostlook.css', opts)
-      .pipe(postcss([autoprefixer, preview ? () => {} : cssnano({
-        preset: 'default',
-      }),
-      ])),
+    vfs.src('css/boostlook.css', opts).pipe(
+      postcss([
+        autoprefixer,
+        preview
+          ? () => {}
+          : cssnano({
+            preset: 'default',
+          }),
+      ])
+    ),
     vfs
       .src(['css/site.css', 'css/vendor/*.css'], { ...opts, sourcemaps })
       .pipe(postcss((file) => ({ plugins: postcssPlugins, options: { file } }))),

--- a/antora-ui/index.js
+++ b/antora-ui/index.js
@@ -1,4 +1,4 @@
 'use strict'
-  
+
 // This placeholder script allows this package to be discovered using require.resolve.
 // It may be used in the future to export information about the files in this UI.

--- a/antora-ui/package-lock.json
+++ b/antora-ui/package-lock.json
@@ -37,7 +37,7 @@
         "gulp-uglify": "~3.0",
         "gulp-vinyl-zip": "~2.2",
         "handlebars": "~4.7",
-        "highlight.js": "9.18.3",
+        "highlight.js": "^11.9.0",
         "js-yaml": "~3.13",
         "merge-stream": "~2.0",
         "postcss-calc": "~7.0",
@@ -6815,13 +6815,13 @@
       "dev": true
     },
     "node_modules/highlight.js": {
-      "version": "9.18.3",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.18.3.tgz",
-      "integrity": "sha512-zBZAmhSupHIl5sITeMqIJnYCDfAEc3Gdkqj65wC1lpI468MMQeeQkhcIAvk+RylAkxrCcI9xy9piHiXeQ1BdzQ==",
-      "deprecated": "Version no longer supported. Upgrade to @latest",
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
+      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "engines": {
-        "node": "*"
+        "node": ">=12.0.0"
       }
     },
     "node_modules/hmac-drbg": {

--- a/antora-ui/package.json
+++ b/antora-ui/package.json
@@ -40,7 +40,7 @@
     "gulp-uglify": "~3.0",
     "gulp-vinyl-zip": "~2.2",
     "handlebars": "~4.7",
-    "highlight.js": "9.18.3",
+    "highlight.js": "^11.9.0",
     "js-yaml": "~3.13",
     "merge-stream": "~2.0",
     "postcss-calc": "~7.0",

--- a/antora-ui/src/js/vendor/highlight.bundle.js
+++ b/antora-ui/src/js/vendor/highlight.bundle.js
@@ -1,43 +1,12 @@
 ;(function () {
   'use strict'
 
-  var hljs = require('highlight.js/lib/highlight')
-  hljs.registerLanguage('asciidoc', require('highlight.js/lib/languages/asciidoc'))
-  hljs.registerLanguage('bash', require('highlight.js/lib/languages/bash'))
-  hljs.registerLanguage('clojure', require('highlight.js/lib/languages/clojure'))
-  hljs.registerLanguage('cpp', require('highlight.js/lib/languages/cpp'))
+  var hljs = require('highlight.js/lib/common')
+
+  // Only register languages not included in common bundle
   hljs.registerLanguage('cmake', require('highlight.js/lib/languages/cmake'))
-  hljs.registerLanguage('cs', require('highlight.js/lib/languages/cs'))
-  hljs.registerLanguage('css', require('highlight.js/lib/languages/css'))
-  hljs.registerLanguage('diff', require('highlight.js/lib/languages/diff'))
-  hljs.registerLanguage('dockerfile', require('highlight.js/lib/languages/dockerfile'))
-  hljs.registerLanguage('elixir', require('highlight.js/lib/languages/elixir'))
-  hljs.registerLanguage('go', require('highlight.js/lib/languages/go'))
-  hljs.registerLanguage('groovy', require('highlight.js/lib/languages/groovy'))
-  hljs.registerLanguage('haskell', require('highlight.js/lib/languages/haskell'))
-  hljs.registerLanguage('java', require('highlight.js/lib/languages/java'))
-  hljs.registerLanguage('javascript', require('highlight.js/lib/languages/javascript'))
-  hljs.registerLanguage('json', require('highlight.js/lib/languages/json'))
-  hljs.registerLanguage('kotlin', require('highlight.js/lib/languages/kotlin'))
-  hljs.registerLanguage('lua', require('highlight.js/lib/languages/lua'))
-  hljs.registerLanguage('markdown', require('highlight.js/lib/languages/markdown'))
-  hljs.registerLanguage('nix', require('highlight.js/lib/languages/nix'))
-  hljs.registerLanguage('none', require('highlight.js/lib/languages/plaintext'))
-  hljs.registerLanguage('objectivec', require('highlight.js/lib/languages/objectivec'))
-  hljs.registerLanguage('perl', require('highlight.js/lib/languages/perl'))
-  hljs.registerLanguage('php', require('highlight.js/lib/languages/php'))
-  hljs.registerLanguage('properties', require('highlight.js/lib/languages/properties'))
-  hljs.registerLanguage('puppet', require('highlight.js/lib/languages/puppet'))
-  hljs.registerLanguage('python', require('highlight.js/lib/languages/python'))
-  hljs.registerLanguage('ruby', require('highlight.js/lib/languages/ruby'))
-  hljs.registerLanguage('rust', require('highlight.js/lib/languages/rust'))
-  hljs.registerLanguage('scala', require('highlight.js/lib/languages/scala'))
-  hljs.registerLanguage('shell', require('highlight.js/lib/languages/shell'))
-  hljs.registerLanguage('sql', require('highlight.js/lib/languages/sql'))
-  hljs.registerLanguage('swift', require('highlight.js/lib/languages/swift'))
-  hljs.registerLanguage('xml', require('highlight.js/lib/languages/xml'))
-  hljs.registerLanguage('yaml', require('highlight.js/lib/languages/yaml'))
-  ;[].slice.call(document.querySelectorAll('pre code.hljs[data-lang]')).forEach(function (node) {
-    hljs.highlightBlock(node)
-  })
+
+  hljs.highlightAll()
+
+  window.hljs = hljs
 })()

--- a/antora-ui/tailwind.config.js
+++ b/antora-ui/tailwind.config.js
@@ -4,5 +4,5 @@ module.exports = {
   theme: {
     extend: {},
   },
-  plugins: []
+  plugins: [],
 }


### PR DESCRIPTION
- upgrade highlight.js from 9.18.3 to 11.9.0
- simplify highlight.bundle.js by using common bundle and automatic language detection
- update build configuration for css processing
- update package.json and package-lock.json dependencies
- fix javascript lint errors

fixes #397