### PR TITLE
feat: branch-specific boostlook css handling

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,11 @@ on:
       - master
       - develop
   workflow_dispatch:
+    inputs:
+      boostlook_branch:
+        description: 'Branch to use for boostlook.css'
+        required: true
+        default: 'master'
 
 concurrency:
   group: ${{format('publish-{0}:{1}', github.repository, github.ref)}}
@@ -109,7 +114,7 @@ jobs:
           set -x
           # Comment out dynamic branch selection for now
           # BOOSTLOOK_BRANCH="${{ (startsWith(github.ref, 'refs/heads/develop') && 'develop') || 'master' }}"
-          export BOOSTLOOK_BRANCH="master"
+          export BOOSTLOOK_BRANCH="${{ github.event.inputs.boostlook_branch || 'master' }}"
           ./build.sh
 
       - name: Setup Ninja

--- a/.github/workflows/ui-release.yml
+++ b/.github/workflows/ui-release.yml
@@ -14,6 +14,11 @@ on:
   pull_request:
     branches: [ "master", "develop" ]
   workflow_dispatch:
+    inputs:
+      boostlook_branch:
+        description: 'Branch to use for boostlook.css'
+        required: true
+        default: 'master'
 
 concurrency:
   group: ${{format('ui-release-{0}:{1}', github.repository, github.ref)}}
@@ -41,6 +46,7 @@ jobs:
     - name: Build
       working-directory: antora-ui
       run: |
+        export BOOSTLOOK_BRANCH="${{ github.event.inputs.boostlook_branch || 'master' }}"
         npm ci
         gulp bundle
 

--- a/antora-ui/gulp.d/tasks/build.js
+++ b/antora-ui/gulp.d/tasks/build.js
@@ -244,6 +244,10 @@ function getAllTasks (opts, sourcemaps, postcssPlugins, preview, src) {
 
     In CI, the file won't be available so it always
     uses the most recent version.
+
+    CSS Branch handling:
+    - master: Uses production version of boostlook styling
+    - develop: Uses Tino Agency's redesign work for staging deployment
  */
 async function fetchBoostlookCss () {
   log('Fetching boostlook.css file...')
@@ -251,7 +255,8 @@ async function fetchBoostlookCss () {
   const cssDir = ospath.join(__dirname, '..', '..', 'src', 'css')
   const cssFilePath = ospath.join(cssDir, 'boostlook.css')
   const boostlookBranch = process.env.BOOSTLOOK_BRANCH || 'master'
-  const url = `https://raw.githubusercontent.com/cppalliance/boostlook/${boostlookBranch}/boostlook.css`
+  const sourceFilename = boostlookBranch === 'develop' ? 'boostlook_tino.css' : 'boostlook.css'
+  const url = `https://raw.githubusercontent.com/boostorg/boostlook/${boostlookBranch}/${sourceFilename}`
 
   if (skipBoostlook) {
     log('Skipping boostlook.css download due to --skip-boostlook flag.')


### PR DESCRIPTION
Implement logic to fetch different CSS files based on target environment:
- master branch: Uses production boostlook.css
- develop branch: Uses Tino Agency's boostlook_tino.css for staging