### PR TITLE
Review Results table updated to March 2025

### DIFF
--- a/formal-reviews/modules/ROOT/pages/review-results.adoc
+++ b/formal-reviews/modules/ROOT/pages/review-results.adoc
@@ -19,7 +19,9 @@ In addition to upcoming reviews, the schedule includes recent reviews already co
 [cols="1,1,1,2,2",stripes=even,options="header",frame=none]
 |===
 | *Submission* | *Submitter* | *Review Manager* | *Review Dates* | *Result*
-| 			| 			| 			| 			|
+| https://jll63.github.io/Boost.OpenMethod/[OpenMethod] | Jean-Louis Leroy | TBD | TBD | TBD
+
+| *Boost 1.88.0 Beta* |  - |   Marshall Clow |  TBD | https://www.boost.org/users/history/version_1_88_0.html[Notes] 
 |===
 
 === Review Managers
@@ -32,29 +34,68 @@ In order for a review to proceed, a Boost member must volunteer to manage the re
 [cols="1,1,1,2,2",stripes=even,options="header",frame=none]
 |===
 | *Submission* | *Submitter* | *Review Manager* | *Review Dates* | *Result*
-| Parser | Zach Laine | Marshall Clow | February 19, 2024 - February 28, 2024 | [.line-through]#https://lists.boost.org/Archives/boost/2024/02/255957.php[Pending]# https://lists.boost.org/Archives/boost/2024/03/256151.php[Conditionally Accepted]
+
+| Decimal  | Matt Borland and Chris Kormanyos | John Maddock | January 15, 2025 - January 22, 2025 | https://lists.boost.org/Archives/boost//2025/02/259187.php[Indeterminate]
+
+| Hash2 | Peter Dimov and Christian Mazakas | Matt Borland | December 7, 2024 - December 15, 2024 | https://lists.boost.org/Archives/boost//2024/12/258910.php[Accepted] Added in 1.88.0
+
+| *Boost 1.87.0 Released* |  - |   Marshall Clow |  December 11, 2024 | https://www.boost.org/users/history/version_1_87_0.html[Notes] 
+
+| SQLite | Klemens Morgenstern | Richard Hodgesn | November 13, 2024 - November 22, 2024 | https://lists.boost.org/Archives/boost/2025/02/259197.php[Indeterminate]
+
+| MQTT5 | Ivica Siladic | Klemens Morgenstern | October 16, 2024 - October 25, 2024 | https://lists.boost.org/Archives/boost//2024/10/258197.php[Conditionally Accepted] Added in 1.88.0
+
+| Boost Fiscal Sponsorship | Vinnie Falco | Glen Fernandes | September 3, 2024 - September 22, 2024 | https://lists.boost.org/Archives/boost/2024/09/257941.php[Accepted]
+
+| *Boost 1.86.0 Released* |  - |   Marshall Clow |  August 14, 2024 | https://www.boost.org/users/history/version_1_86_0.html[Notes] 
+
+| *Boost 1.85.0 Released* |  - |   Marshall Clow |  April 15, 2024 | https://www.boost.org/users/history/version_1_85_0.html[Notes]
+
+| Parser | Zach Laine | Marshall Clow | February 19, 2024 - February 28, 2024 | [.line-through]#https://lists.boost.org/Archives/boost/2024/02/255957.php[Pending]# https://lists.boost.org/Archives/boost/2024/03/256151.php[Conditionally Accepted] Added in 1.87.0
 
 | CharConv | Matt Borland | Christopher Kormanyos | January 15, 2024 - January 25, 2024 | [.line-through]#https://lists.boost.org/Archives/boost/2024/01/255713.php[Pending]# https://lists.boost.org/Archives/boost/2024/02/255820.php[Accepted] Added in 1.85
+
+| *Boost 1.84.0 Released* |  - |   Marshall Clow |  December 13, 2023 | https://www.boost.org/users/history/version_1_84_0.html[Notes] 
 
 | Cobalt (fka Async) | Klemens Morgenstern | Niall Douglas | September 22, 2023 - October 2, 2023 https://lists.boost.org/Archives/boost/2023/08/254947.php[repeated due lack of reviews] | [.line-through]#https://lists.boost.org/Archives/boost/2023/09/254987.php[Pending]# https://lists.boost.org/Archives/boost/2023/10/255139.php[Conditionally Accepted] -- Added in 1.84
 
 | Scope | Andrey Semashev | Dmitry Arkhipov | November 26, 2023 - December 5, 2023 | [.line-through]#https://lists.boost.org/Archives/boost/2023/11/255367.php[Pending]# https://lists.boost.org/Archives/boost/2024/01/255717.php[Conditionally Accepted] -- Added in 1.85
 
+| *Boost 1.83.0 Released* |  - |   Marshall Clow |  August 11, 2023 | https://www.boost.org/users/history/version_1_83_0.html[Notes] 
+
+| *Boost 1.82.0 Released* |  - |   Marshall Clow |  April 14, 2023 | https://www.boost.org/users/history/version_1_82_0.html[Notes]
+
 | Mustache | Peter Dimov | Klemens Morgenstern | February 5, 2023 - February 14, 2023 | [.line-through]#https://lists.boost.org/Archives/boost/2023/02/254011.php[Pending]# https://lists.boost.org/Archives/boost/2023/02/254188.php[Rejected]
 
 | Redis (fka Aedis) | Marcelo Zimbres Silva | Klemens Morgenstern | January 15, 2023 - January 24, 2023 | [.line-through]#https://lists.boost.org/Archives/boost/2023/01/253871.php[Pending]# https://lists.boost.org/Archives/boost/2023/01/253944.php[Conditionally Accepted] -- Added in 1.84
 
+| *Boost 1.81.0 Released* |  - |   Marshall Clow |  December 14, 2022 | https://www.boost.org/users/history/version_1_81_0.html[Notes]
+
 | URL | Vinnie Falco, Alan de Freitas | Klemens Morgenstern | August 13, 2022 - August 22, 2022 | [.line-through]#https://lists.boost.org/Archives/boost/2022/05/252898.php[Pending]# https://lists.boost.org/Archives/boost//2022/08/253509.php[Accepted] Added in 1.81
 
+| *Boost 1.80.0 Released* |  - |   Marshall Clow |  August 10, 2022 | https://www.boost.org/users/history/version_1_80_0.html[Notes]
+
 | MySQL | Ruben Perez | Richard Hodges | May 9, 2022 - May 18, 2022 | [.line-through]#https://lists.boost.org/Archives/boost/2022/05/252898.php[Pending]# https://lists.boost.org/Archives/boost//2022/06/253193.php[Accepted] Added in 1.82
+
+| *Boost 1.79.0 Released* |  - |   Marshall Clow |  April 13, 2022 | https://www.boost.org/users/history/version_1_79_0.html[Notes]
+
+| *Boost 1.78.0 Released* |  - |   Marshall Clow |  December 8, 2021 | https://www.boost.org/users/history/version_1_78_0.html[Notes]
+
+| *Boost 1.77.0 Released* |  - |   Marshall Clow |  August 11, 2021 | https://www.boost.org/users/history/version_1_77_0.html[Notes]
+
+| *Boost 1.76.0 Released* |  - |   Marshall Clow |  April 16, 2021 | https://www.boost.org/users/history/version_1_76_0.html[Notes]
 
 | Lambda2 | Peter Dimov | Joel de Guzman | March 22, 2021 - March 31, 2021 | [.line-through]#https://lists.boost.org/Archives/boost/2021/03/251218.php[Pending]# https://lists.boost.org/Archives/boost/2021/04/251393.php[Accepted] Added in 1.77
 
 |  Describe | Peter Dimov | Richard Hodges | March 1, 2021 - March 10, 2021 | [.line-through]#https://lists.boost.org/Archives/boost/2021/02/250933.php[Pending]# https://lists.boost.org/Archives/boost/2021/03/251099.php[Accepted] Added in 1.77
 
+| *Boost 1.75.0 Released* |  - |   Marshall Clow |  December 11, 2020 | https://www.boost.org/users/history/version_1_75_0.html[Notes]
+
 | PFR(Precise and Flat Reflection) | Antony Polukhin | Benedek Thaler | September 28, 2020 - October 7, 2020 | [.line-through]#https://lists.boost.org/Archives/boost/2020/09/250077.php[Pending]# https://lists.boost.org/Archives/boost/2020/10/250176.php[Accepted] Added in 1.75
 
 | JSON | Vinnie Falco, Krystian Stasiowski | Pranam Lashkari | September 14, 2020 - September 23, 2020 | [.line-through]#https://lists.boost.org/Archives/boost/2020/09/249708.php[Pending]# https://lists.boost.org/Archives/boost/2020/10/250129.php[Accepted] Added in 1.75
+
+| *Boost 1.74.0 Released* |  - |   Marshall Clow |  August 14, 2020 | https://www.boost.org/users/history/version_1_74_0.html[Notes]
 
 | LEAF(Lightweight Error Augmentation Framework) | Emil Dotchevski | Michael Caisse | May 22, 2020 - May 31, 2020 | [.line-through]#https://lists.boost.org/Archives/boost/2020/05/248850.php[Pending]# https://lists.boost.org/Archives/boost/2020/08/249657.php[Accepted] Added in 1.75
 


### PR DESCRIPTION
Updated Formal Review Results table with latest libs (Hash2, Decimal, etc.) and missing Release dates and links. Also added current proposal OpenMethod and 1.88 beta links.

fix #424

@cdw9 this look right?