### PR TITLE
Bumped CMake version to 3.5

### DIFF
--- a/user-guide/modules/ROOT/pages/getting-started.adoc
+++ b/user-guide/modules/ROOT/pages/getting-started.adoc
@@ -609,7 +609,7 @@ Here's an example `CMakeLists.txt` file that uses Boost:
 [source,cmake]
 .CMakeLists.txt
 ----
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(MyProject)
 
 find_package(Boost REQUIRED)
@@ -779,7 +779,7 @@ Edit the contents of `CMakeLists.txt`:
 [source,cmake]
 .CMakeLists.txt
 ----
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(MyProject)
 
 find_package(Boost REQUIRED COMPONENTS json)


### PR DESCRIPTION
With the release of CMake 4.0, compatibility with versions older than 3.5 has been removed. Calls to cmake_minimum_required with older version result in a fatal error. 