### PR TITLE
remove wrapper id from main boostlook class div

### DIFF
--- a/antora-ui/src/partials/body.hbs
+++ b/antora-ui/src/partials/body.hbs
@@ -1,4 +1,4 @@
-<div class="boostlook" id="antora-template-wrapper">
+<div class="boostlook">
   {{> header}}
   {{> main}}
   {{> footer}}


### PR DESCRIPTION
Removes unnecessary `#antora-template-wrapper` wrapper ID that was previously thought to be needed.