### PR TITLE
Improved `release_notes/template.adoc`

### DIFF
--- a/release-notes/template.adoc
+++ b/release-notes/template.adoc
@@ -1,39 +1,41 @@
 ////
-Copyright (c) 2024 The C++ Alliance, Inc. (https://cppalliance.org)
 Distributed under the Boost Software License, Version 1.0. (See accompanying
 file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 Official repository: https://github.com/boostorg/website-v2-docs
 ////
-= Release Notes
-These are the release notes for Boost version X.XX.XX.
+
+== Version X.XX.XX
+
+// Date of release
+Month Day, Year Hour::Minute GMT
+
+https://www.boost.org/doc/libs/X_XX_X/[Documentation]
+
+// Formatting reference: https://docs.asciidoctor.org/asciidoc/latest/syntax-quick-reference/
+// Please keep the list of libraries sorted in lexicographical order.
+
 == New Libraries
-// List new libraries in lexicographical order (library name, purpose, authors)
+
 // Example:
-// * Accumulators : performs incremental calculation, and collection of statistical accumulators, from Eric Niebler.
-* Library 1 name : purpose, author
-* Library 2 name : purpose, author
+//
+// * phrase::[library,at::/libs/accumulators/[Accumulators]:] Framework for
+// incremental calculation, and collection of statistical accumulators, from Eric Niebler.
+
 == Updated Libraries
-// List updated libraries in lexicographical order.
+
 // Example:
-// * Interprocess
-// ** Dependency on Boost.TypeTraits removed
-// ** Shared memory feature added
-// ** Support for C++ 03 removed
-* Library 1 name
-** update 1 text
-*** indented note for update 1, if needed
-*** another indented note for update 1, if needed
-** update 2 text
-** update 3 text
-* Library 2 name
-** update 1 text
-*** indented note for update 1, if needed
-*** another indented note for update 1, if needed
-** update 2 text
-** update 3 text
+// 
+// * phrase::[library,at::/libs/Interprocess/[Interprocess]:]
+// ** Added anonymous shared memory for UNIX systems.
+// ** Conform to `std::pointer_traits` requirements (github_pr::[interprocess,32]).
+// ** Fixed `named_condition_any` fails to notify (github_issue::[interprocess,62]).
+
 == Compilers Tested
+
 // Edit this section as approrpriate
+
 Boost's primary test compilers are:
+
 * Linux:
 ** Clang, C++03: 3.4, 3.5, 3.6, 3.7, 3.8, 3.9, 12.0.0, 13.0.0, 14.0.0, 15.0.0
 ** Clang, C++11: 3.4, 11.0.0, 13.0.0, 14.0.0, 15.0.0
@@ -53,7 +55,9 @@ Boost's primary test compilers are:
 ** Apple Clang, C++20: 11.0.3
 * Windows:
 ** Visual C++: 10.0, 11.0, 12.0, 14.0, 14.1, 14.2, 14.3
+
 == Acknowledgements
-// Example:  * Marshall Clow and Glen Fernandes managed this release.
-* ack 1
-* ack 2
+
+// Edit this section as approrpriate
+
+Marshall Clow, Glen Fernandes and Ion Gaztañaga managed this release. 

--- a/release-notes/template.adoc
+++ b/release-notes/template.adoc
@@ -25,7 +25,7 @@ https://www.boost.org/doc/libs/X_XX_X/[Documentation]
 
 // Example:
 // 
-// * phrase::[library,at::/libs/Interprocess/[Interprocess]:]
+// * phrase::[library,at::/libs/interprocess/[Interprocess]:]
 // ** Added anonymous shared memory for UNIX systems.
 // ** Conform to `std::pointer_traits` requirements (github_pr::[interprocess,32]).
 // ** Fixed `named_condition_any` fails to notify (github_issue::[interprocess,62]).

--- a/release-notes/template.adoc
+++ b/release-notes/template.adoc
@@ -32,7 +32,7 @@ https://www.boost.org/doc/libs/X_XX_X/[Documentation]
 
 == Compilers Tested
 
-// Edit this section as approrpriate
+// Edit this section as appropriate
 
 Boost's primary test compilers are:
 
@@ -58,6 +58,6 @@ Boost's primary test compilers are:
 
 == Acknowledgements
 
-// Edit this section as approrpriate
+// Edit this section as appropriate
 
 Marshall Clow, Glen Fernandes and Ion Gaztañaga managed this release. 

--- a/release-notes/template.adoc
+++ b/release-notes/template.adoc
@@ -9,26 +9,28 @@ Official repository: https://github.com/boostorg/website-v2-docs
 // Date of release
 Month Day, Year Hour::Minute GMT
 
-https://www.boost.org/doc/libs/X_XX_X/[Documentation]
+boost_at:/doc/libs/X_XX_X/[Documentation]
 
 // Formatting reference: https://docs.asciidoctor.org/asciidoc/latest/syntax-quick-reference/
+// Boost-specific macros: https://github.com/cppalliance/asciidoctor-boost?tab=readme-ov-file#macros
 // Please keep the list of libraries sorted in lexicographical order.
 
 == New Libraries
 
 // Example:
-//
-// * phrase::[library,at::/libs/accumulators/[Accumulators]:] Framework for
-// incremental calculation, and collection of statistical accumulators, from Eric Niebler.
+// 
+// * boost_phrase:library[Accumulators,/libs/accumulators]:
+// ** Framework for incremental calculation, and collection of statistical
+// accumulators, from Eric Niebler.
 
 == Updated Libraries
 
 // Example:
-// 
-// * phrase::[library,at::/libs/interprocess/[Interprocess]:]
+//  
+// * boost_phrase:library[Interprocess,/libs/interprocess/]:
 // ** Added anonymous shared memory for UNIX systems.
-// ** Conform to `std::pointer_traits` requirements (github_pr::[interprocess,32]).
-// ** Fixed `named_condition_any` fails to notify (github_issue::[interprocess,62]).
+// ** Conform to `std::pointer_traits` requirements (boost_gh:pr[interprocess,32]).
+// ** Fixed `named_condition_any` fails to notify (boost_gh:issue[interprocess,62]).
 
 == Compilers Tested
 
@@ -60,4 +62,4 @@ Boost's primary test compilers are:
 
 // Edit this section as appropriate
 
-Marshall Clow, Glen Fernandes and Ion Gaztañaga managed this release. 
+Marshall Clow, Glen Fernandes and Ion Gaztañaga managed this release.


### PR DESCRIPTION
Ths version of of `release_notes/template.adoc`:

* Follows the classical structure of release notes as exemplified [here](https://github.com/boostorg/website/blob/master/feed/history/boost_1_90_0.qbk) (translating Quickbook to Asciidoc).
* Shows examples of use of the supporting macros developed in https://github.com/boostorg/website-v2/pull/1377.

As I don't have the means to see the macros in action, it's important that someone who has validates this template.